### PR TITLE
v1.4.7-1.4.8: self-registering routes + Kafka adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Legion::Transport ChangeLog
 
+## [1.4.8] - 2026-03-28
+
+### Added
+- `Legion::Transport::Kafka` optional adapter for event streaming alongside RabbitMQ (closes #4)
+- `Kafka::Producer` — thread-safe rdkafka producer with lazy init, JSON auto-encoding, partition key, header forwarding, and delivery confirmation
+- `Kafka::Consumer` — subscribe to topics with consumer group semantics; replay from offset or timestamp via isolated replay group
+- `Kafka::Admin` — idempotent `ensure_topic` (create or confirm-exists) via rdkafka admin client
+- `Kafka::IncomingMessage` — clean wrapper over raw rdkafka messages exposing topic/partition/offset/key/headers/timestamp/payload with `decoded_payload` JSON parse helper
+- `Kafka::DEFAULTS` — full default config hash covering producer, consumer, admin, and security (SASL/SSL) settings; all values env-var overridable under `transport.kafka.*` namespace
+- `Legion::Transport::Settings.kafka` — merges Kafka defaults into the transport settings hash; `transport.kafka.enabled: false` by default
+- Feature-flagged: Kafka is opt-in (`transport.kafka.enabled: true` or `ENV['transport.kafka.enabled'] = 'true'`); `rdkafka` gem is a soft optional dependency not listed in gemspec
+- 56 new specs covering the Kafka module, Producer, IncomingMessage, and DEFAULTS (all rdkafka interaction mocked — no broker required)
+
 ## [1.4.7] - 2026-03-28
 
 ### Added

--- a/lib/legion/transport.rb
+++ b/lib/legion/transport.rb
@@ -69,4 +69,5 @@ module Legion
   require_relative 'transport/tenant_provisioner'
   require_relative 'transport/tenant_quota'
   require_relative 'transport/helper'
+  require_relative 'transport/kafka'
 end

--- a/lib/legion/transport/kafka.rb
+++ b/lib/legion/transport/kafka.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+require_relative 'kafka/errors'
+require_relative 'kafka/producer'
+require_relative 'kafka/consumer'
+require_relative 'kafka/admin'
+
+module Legion
+  module Transport
+    # Optional Kafka adapter for event streaming alongside RabbitMQ.
+    #
+    # Kafka is NOT a replacement for RabbitMQ task dispatch — it runs alongside
+    # for patterns that need durable, replayable, append-only event logs:
+    #   - Telemetry / metrics pipelines
+    #   - Audit event streams
+    #   - Change data capture / event sourcing
+    #   - Consumer group fan-out with independent offset tracking
+    #
+    # Feature-flagged via +transport.kafka.enabled: false+ (default off).
+    # Requires the +rdkafka+ gem as an optional runtime dependency.
+    #
+    # Usage:
+    #   Legion::Transport::Kafka.publish('legion.audit', { event: 'login' })
+    #   Legion::Transport::Kafka.subscribe('legion.telemetry', group: 'metrics') do |msg|
+    #     process(msg)
+    #   end
+    #   Legion::Transport::Kafka.replay('legion.audit', from_beginning: true) do |msg|
+    #     reprocess(msg)
+    #   end
+    module Kafka
+      class << self
+        # Returns true when the Kafka adapter is enabled and rdkafka is available.
+        def enabled?
+          return false unless kafka_settings[:enabled]
+
+          require_rdkafka
+          true
+        rescue Legion::Transport::Kafka::UnavailableError
+          false
+        end
+
+        # Publish a single message to a Kafka topic.
+        #
+        # @param topic [String] Kafka topic name
+        # @param payload [String, Hash] message body; Hash is JSON-encoded automatically
+        # @param key [String, nil] optional partition key
+        # @param headers [Hash] optional message headers
+        # @param partition [Integer, nil] explicit partition (nil = auto-assigned)
+        # @return [Hash] delivery report { topic:, partition:, offset: }
+        def publish(topic, payload, key: nil, headers: {}, partition: nil)
+          require_enabled!
+          Producer.publish(topic, payload, key: key, headers: headers, partition: partition)
+        end
+
+        # Subscribe to a Kafka topic with consumer group semantics.
+        # Runs the block synchronously in the calling thread for each message.
+        # For background polling, wrap in a Thread / actor.
+        #
+        # @param topic [String, Array<String>] topic(s) to subscribe to
+        # @param group [String] consumer group ID (default from settings)
+        # @param from_beginning [Boolean] start from earliest offset (default false = latest)
+        # @param max_messages [Integer, nil] stop after N messages (nil = run forever)
+        # @yield [message] called for each received message
+        # @yieldparam message [Legion::Transport::Kafka::IncomingMessage]
+        def subscribe(topic, group: default_group, from_beginning: false, max_messages: nil, &)
+          require_enabled!
+          Consumer.subscribe(topic, group: group, from_beginning: from_beginning,
+                                    max_messages: max_messages, &)
+        end
+
+        # Replay a topic from a specific point.
+        # Creates an isolated consumer group for the replay session so that production
+        # offsets are not disturbed.
+        #
+        # @param topic [String] topic to replay
+        # @param from_beginning [Boolean] start from offset 0 (default true for replay)
+        # @param from_offset [Integer, nil] explicit partition-0 offset to start from
+        # @param from_timestamp [Time, nil] seek to offset nearest this timestamp
+        # @param replay_group [String] temporary consumer group ID
+        # @yield [message] called for each replayed message
+        def replay(topic, from_beginning: true, from_offset: nil, from_timestamp: nil,
+                   replay_group: "legion-replay-#{SecureRandom.hex(4)}", &)
+          require_enabled!
+          Consumer.replay(topic,
+                          from_beginning: from_beginning,
+                          from_offset:    from_offset,
+                          from_timestamp: from_timestamp,
+                          replay_group:   replay_group,
+                          &)
+        end
+
+        # Create a Kafka topic via the admin client.
+        # Idempotent — returns true if the topic already exists.
+        #
+        # @param topic [String]
+        # @param partitions [Integer]
+        # @param replication_factor [Integer]
+        # @param config [Hash] topic-level Kafka configs (e.g. retention.ms)
+        def ensure_topic(topic, partitions: 1, replication_factor: 1, config: {})
+          require_enabled!
+          Admin.ensure_topic(topic, partitions:         partitions,
+                                    replication_factor: replication_factor,
+                                    config:             config)
+        end
+
+        # Returns the Kafka brokers list from settings.
+        def brokers
+          Array(kafka_settings[:brokers]).flatten.compact
+        end
+
+        # Returns the default consumer group from settings.
+        def default_group
+          kafka_settings[:consumer_group] || 'legion'
+        end
+
+        # Returns the raw Kafka settings hash.
+        def kafka_settings
+          Legion::Settings[:transport][:kafka]
+        rescue StandardError
+          Legion::Transport::Kafka::DEFAULTS
+        end
+
+        # Resets internal producer/consumer state (useful in tests).
+        def reset!
+          Producer.reset!
+          Consumer.reset!
+        end
+
+        private
+
+        def require_enabled!
+          raise Legion::Transport::Kafka::DisabledError, 'Kafka adapter is not enabled (transport.kafka.enabled: false)' unless kafka_settings[:enabled]
+
+          require_rdkafka
+        end
+
+        def require_rdkafka
+          require 'rdkafka'
+        rescue LoadError
+          raise Legion::Transport::Kafka::UnavailableError,
+                'rdkafka gem is required for Kafka support — add gem "rdkafka" to your Gemfile'
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/transport/kafka/admin.rb
+++ b/lib/legion/transport/kafka/admin.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require_relative 'defaults'
+
+module Legion
+  module Transport
+    module Kafka
+      # Thin wrapper around rdkafka admin operations.
+      # Used internally to ensure topics exist before publishing/subscribing.
+      module Admin
+        class << self
+          # Idempotently create a topic. Returns true if the topic was created or
+          # already exists, raises AdminError on other failures.
+          #
+          # @param topic              [String]
+          # @param partitions         [Integer]
+          # @param replication_factor [Integer]
+          # @param config             [Hash] topic-level config (e.g. +'retention.ms'+ => '604800000')
+          # @return [Boolean]
+          def ensure_topic(topic, partitions: 1, replication_factor: 1, config: {})
+            admin  = build_admin
+            handle = admin.create_topic(topic, partitions, replication_factor, config)
+            handle.wait(max_wait_timeout: operation_timeout)
+            log_created(topic, partitions)
+            true
+          rescue ::Rdkafka::RdkafkaError => e
+            # Error code 36 = TOPIC_ALREADY_EXISTS — not a real error for our purposes.
+            return true if e.respond_to?(:code) && e.code == :topic_already_exists
+            return true if e.message.to_s.include?('TOPIC_ALREADY_EXISTS') || e.message.to_s.include?('Topic already exists')
+
+            raise Legion::Transport::Kafka::AdminError, "ensure_topic(#{topic}) failed: #{e.message}"
+          rescue StandardError => e
+            raise Legion::Transport::Kafka::AdminError, "ensure_topic(#{topic}) failed: #{e.message}"
+          ensure
+            admin&.close rescue nil # rubocop:disable Style/RescueModifier
+          end
+
+          private
+
+          def build_admin
+            brokers = Array(Legion::Transport::Kafka.kafka_settings[:brokers]).join(',')
+            cfg     = {
+              'bootstrap.servers'  => brokers,
+              'request.timeout.ms' => operation_timeout_ms
+            }
+            security = Legion::Transport::Kafka.kafka_settings[:security] || DEFAULTS[:security]
+            apply_security!(cfg, security)
+            ::Rdkafka::Config.new(cfg).admin
+          end
+
+          def apply_security!(cfg, sec)
+            protocol = (sec[:protocol] || 'plaintext').to_s
+            cfg['security.protocol'] = protocol
+            return if protocol == 'plaintext'
+
+            if sec[:sasl_mechanism].to_s != ''
+              cfg['sasl.mechanism'] = sec[:sasl_mechanism].to_s
+              cfg['sasl.username']  = sec[:sasl_username].to_s
+              cfg['sasl.password']  = sec[:sasl_password].to_s
+            end
+
+            cfg['ssl.ca.location']          = sec[:ssl_ca_cert_path].to_s          if sec[:ssl_ca_cert_path].to_s != ''
+            cfg['ssl.certificate.location'] = sec[:ssl_client_cert_path].to_s      if sec[:ssl_client_cert_path].to_s != ''
+            cfg['ssl.key.location']         = sec[:ssl_client_cert_key_path].to_s  if sec[:ssl_client_cert_key_path].to_s != ''
+          end
+
+          def operation_timeout
+            operation_timeout_ms / 1_000.0
+          end
+
+          def operation_timeout_ms
+            settings = Legion::Transport::Kafka.kafka_settings
+            ((settings[:admin] || DEFAULTS[:admin])[:operation_timeout_ms] || 10_000).to_i
+          end
+
+          def log_created(topic, partitions)
+            return unless defined?(Legion::Logging)
+
+            Legion::Logging.info("Kafka topic created topic=#{topic} partitions=#{partitions}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/transport/kafka/consumer.rb
+++ b/lib/legion/transport/kafka/consumer.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+require_relative 'defaults'
+require_relative 'incoming_message'
+
+module Legion
+  module Transport
+    module Kafka
+      # Consumer wraps rdkafka consumer handles for subscribe and replay operations.
+      # Each subscribe/replay call creates its own isolated consumer handle so that
+      # multiple topics and consumer groups can coexist in a single process.
+      module Consumer
+        class << self
+          # Subscribe to one or more topics and yield each message to the block.
+          # Runs synchronously in the calling thread — wrap in a Thread or actor
+          # for background processing.
+          #
+          # @param topics         [String, Array<String>]
+          # @param group          [String]
+          # @param from_beginning [Boolean] true = earliest, false = latest
+          # @param max_messages   [Integer, nil] stop after N messages; nil = run until stopped
+          # @yield [IncomingMessage]
+          def subscribe(topics, group:, from_beginning: false, max_messages: nil)
+            topic_list = Array(topics)
+            cfg        = consumer_config(group: group, from_beginning: from_beginning)
+            consumer   = ::Rdkafka::Config.new(cfg).consumer
+
+            begin
+              consumer.subscribe(*topic_list)
+              log_subscribe(topic_list, group)
+
+              count = 0
+              loop do
+                message = consumer.poll(poll_timeout_ms)
+                next if message.nil?
+
+                yield IncomingMessage.new(message)
+
+                count += 1
+                commit_if_needed(consumer, count)
+                break if max_messages && count >= max_messages
+              end
+            rescue StopIteration
+              # clean exit from consumer loop
+            ensure
+              consumer.close
+            end
+          rescue StandardError => e
+            raise Legion::Transport::Kafka::ConsumerError, "Kafka consumer error: #{e.message}"
+          end
+
+          # Replay a topic from a specific point without disturbing production offsets.
+          # A temporary consumer group is used so that production group offsets are
+          # unaffected. The consumer reads until caught up to the high-water mark at
+          # the time replay started, then exits.
+          #
+          # @param topic          [String]
+          # @param from_beginning [Boolean]
+          # @param from_offset    [Integer, nil] explicit partition-0 start offset
+          # @param from_timestamp [Time, nil] seek to nearest offset for this timestamp
+          # @param replay_group   [String] isolated group ID for this replay session
+          # @yield [IncomingMessage]
+          def replay(topic, replay_group:, from_beginning: true, from_offset: nil, from_timestamp: nil)
+            cfg      = consumer_config(group: replay_group, from_beginning: from_beginning)
+            consumer = ::Rdkafka::Config.new(cfg).consumer
+
+            begin
+              consumer.subscribe(topic)
+
+              # Seek if an explicit offset or timestamp was provided.
+              if from_offset || from_timestamp
+                seek_consumer(consumer, topic, from_offset:    from_offset,
+                                               from_timestamp: from_timestamp)
+              end
+
+              log_replay(topic, replay_group, from_beginning: from_beginning,
+                                              from_offset:    from_offset,
+                                              from_timestamp: from_timestamp)
+
+              loop do
+                message = consumer.poll(poll_timeout_ms)
+                break if message.nil?
+
+                yield IncomingMessage.new(message)
+              end
+            ensure
+              consumer.close
+            end
+          rescue StandardError => e
+            raise Legion::Transport::Kafka::ConsumerError, "Kafka replay error on #{topic}: #{e.message}"
+          end
+
+          # No persistent state to reset; included for symmetry with Producer.reset!
+          def reset!
+            true
+          end
+
+          private
+
+          def consumer_config(group:, from_beginning:)
+            settings   = Legion::Transport::Kafka.kafka_settings
+            c_settings = settings[:consumer] || DEFAULTS[:consumer]
+            brokers    = Array(settings[:brokers]).join(',')
+
+            auto_reset = from_beginning ? 'earliest' : (c_settings[:auto_offset_reset] || 'latest').to_s
+
+            cfg = {
+              'bootstrap.servers'    => brokers,
+              'group.id'             => group.to_s,
+              'auto.offset.reset'    => auto_reset,
+              'enable.auto.commit'   => (c_settings[:enable_auto_commit] || false).to_s,
+              'max.poll.interval.ms' => (c_settings[:max_poll_interval_ms] || 300_000).to_i,
+              'session.timeout.ms'   => (c_settings[:session_timeout_ms] || 30_000).to_i
+            }
+
+            apply_security!(cfg, settings[:security] || DEFAULTS[:security])
+            cfg
+          end
+
+          def apply_security!(cfg, sec)
+            protocol = (sec[:protocol] || 'plaintext').to_s
+            cfg['security.protocol'] = protocol
+            return if protocol == 'plaintext'
+
+            if sec[:sasl_mechanism].to_s != ''
+              cfg['sasl.mechanism'] = sec[:sasl_mechanism].to_s
+              cfg['sasl.username']  = sec[:sasl_username].to_s
+              cfg['sasl.password']  = sec[:sasl_password].to_s
+            end
+
+            cfg['ssl.ca.location']          = sec[:ssl_ca_cert_path].to_s          if sec[:ssl_ca_cert_path].to_s != ''
+            cfg['ssl.certificate.location'] = sec[:ssl_client_cert_path].to_s      if sec[:ssl_client_cert_path].to_s != ''
+            cfg['ssl.key.location']         = sec[:ssl_client_cert_key_path].to_s  if sec[:ssl_client_cert_key_path].to_s != ''
+          end
+
+          def poll_timeout_ms
+            settings = Legion::Transport::Kafka.kafka_settings
+            ((settings[:consumer] || DEFAULTS[:consumer])[:poll_timeout_ms] || 1_000).to_i
+          end
+
+          def commit_interval
+            settings = Legion::Transport::Kafka.kafka_settings
+            ((settings[:consumer] || DEFAULTS[:consumer])[:commit_interval_messages] || 100).to_i
+          end
+
+          def commit_if_needed(consumer, count)
+            consumer.commit if (count % commit_interval).zero?
+          rescue StandardError => e
+            return unless defined?(Legion::Logging)
+
+            Legion::Logging.warn("Kafka consumer commit failed: #{e.message}")
+          end
+
+          def seek_consumer(consumer, topic, from_offset:, from_timestamp:)
+            # Allow up to 5 polls to let the partition assignment settle.
+            5.times { consumer.poll(200) }
+
+            partition = ::Rdkafka::Consumer::TopicPartitionList.new
+            partition.add_topic_and_partitions_with_offsets(topic,
+                                                            0 => resolve_offset(consumer, topic, from_offset: from_offset, from_timestamp: from_timestamp))
+            consumer.seek_to(partition)
+          rescue StandardError => e
+            return unless defined?(Legion::Logging)
+
+            Legion::Logging.warn("Kafka consumer seek failed: #{e.message}")
+          end
+
+          def resolve_offset(consumer, topic, from_offset:, from_timestamp:)
+            return from_offset if from_offset
+
+            offsets_for_times = ::Rdkafka::Consumer::TopicPartitionList.new
+            offsets_for_times.add_topic_and_partitions_with_offsets(
+              topic, 0 => (from_timestamp.to_f * 1_000).to_i
+            )
+            result = consumer.offsets_for_times(offsets_for_times)
+            result.to_h[topic]&.first&.last || 0
+          rescue StandardError
+            0
+          end
+
+          def log_subscribe(topics, group)
+            return unless defined?(Legion::Logging)
+
+            Legion::Logging.debug("Kafka subscribed topics=#{topics.join(',')} group=#{group}")
+          end
+
+          def log_replay(topic, group, from_beginning:, from_offset:, from_timestamp:)
+            return unless defined?(Legion::Logging)
+
+            desc = if from_offset
+                     "offset=#{from_offset}"
+                   elsif from_timestamp
+                     "timestamp=#{from_timestamp}"
+                   elsif from_beginning
+                     'beginning'
+                   else
+                     'latest'
+                   end
+            Legion::Logging.info("Kafka replay topic=#{topic} from=#{desc} replay_group=#{group}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/transport/kafka/defaults.rb
+++ b/lib/legion/transport/kafka/defaults.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Legion
+  module Transport
+    module Kafka
+      DEFAULTS = {
+        enabled:        false,
+        brokers:        [ENV.fetch('transport.kafka.brokers', '127.0.0.1:9092')],
+        consumer_group: ENV.fetch('transport.kafka.consumer_group', 'legion'),
+        producer:       {
+          acks:               ENV.fetch('transport.kafka.producer.acks', 'all'),
+          retries:            (ENV['transport.kafka.producer.retries'] || 3).to_i,
+          retry_backoff_ms:   (ENV['transport.kafka.producer.retry_backoff_ms'] || 100).to_i,
+          message_timeout_ms: (ENV['transport.kafka.producer.message_timeout_ms'] || 30_000).to_i,
+          compression:        ENV.fetch('transport.kafka.producer.compression', 'none'),
+          batch_size:         (ENV['transport.kafka.producer.batch_size'] || 100).to_i,
+          linger_ms:          (ENV['transport.kafka.producer.linger_ms'] || 5).to_i
+        },
+        consumer:       {
+          poll_timeout_ms:          (ENV['transport.kafka.consumer.poll_timeout_ms'] || 1_000).to_i,
+          max_poll_interval_ms:     (ENV['transport.kafka.consumer.max_poll_interval_ms'] || 300_000).to_i,
+          session_timeout_ms:       (ENV['transport.kafka.consumer.session_timeout_ms'] || 30_000).to_i,
+          auto_offset_reset:        ENV.fetch('transport.kafka.consumer.auto_offset_reset', 'latest'),
+          enable_auto_commit:       ENV.fetch('transport.kafka.consumer.enable_auto_commit', 'false') == 'true',
+          commit_interval_messages: (ENV['transport.kafka.consumer.commit_interval_messages'] || 100).to_i
+        },
+        admin:          {
+          operation_timeout_ms: (ENV['transport.kafka.admin.operation_timeout_ms'] || 10_000).to_i
+        },
+        security:       {
+          protocol:                 ENV.fetch('transport.kafka.security.protocol', 'plaintext'),
+          sasl_mechanism:           ENV.fetch('transport.kafka.security.sasl_mechanism', ''),
+          sasl_username:            ENV.fetch('transport.kafka.security.sasl_username', ''),
+          sasl_password:            ENV.fetch('transport.kafka.security.sasl_password', ''),
+          ssl_ca_cert_path:         ENV.fetch('transport.kafka.security.ssl_ca_cert_path', ''),
+          ssl_client_cert_path:     ENV.fetch('transport.kafka.security.ssl_client_cert_path', ''),
+          ssl_client_cert_key_path: ENV.fetch('transport.kafka.security.ssl_client_cert_key_path', '')
+        }
+      }.freeze
+    end
+  end
+end

--- a/lib/legion/transport/kafka/errors.rb
+++ b/lib/legion/transport/kafka/errors.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Legion
+  module Transport
+    module Kafka
+      # Raised when the Kafka adapter is accessed but disabled in settings.
+      class DisabledError < StandardError; end
+
+      # Raised when the rdkafka gem is not available.
+      class UnavailableError < StandardError; end
+
+      # Raised when a publish operation fails after retries.
+      class PublishError < StandardError; end
+
+      # Raised when a consumer encounters an unrecoverable error.
+      class ConsumerError < StandardError; end
+
+      # Raised when an admin operation fails.
+      class AdminError < StandardError; end
+    end
+  end
+end

--- a/lib/legion/transport/kafka/incoming_message.rb
+++ b/lib/legion/transport/kafka/incoming_message.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Legion
+  module Transport
+    module Kafka
+      # Wraps an rdkafka message with a clean, framework-consistent interface.
+      # Passed to subscriber blocks instead of the raw Rdkafka::Consumer::Message.
+      class IncomingMessage
+        attr_reader :topic, :partition, :offset, :key, :headers, :timestamp, :raw
+
+        def initialize(rdkafka_message)
+          @raw       = rdkafka_message
+          @topic     = rdkafka_message.topic
+          @partition = rdkafka_message.partition
+          @offset    = rdkafka_message.offset
+          @key       = rdkafka_message.key
+          @headers   = rdkafka_message.headers || {}
+          @timestamp = rdkafka_message.timestamp
+          @payload   = rdkafka_message.payload
+        end
+
+        # Returns the raw string payload.
+        attr_reader :payload
+
+        # Attempts to parse the payload as JSON; returns the raw string on failure.
+        def decoded_payload
+          return @payload unless @payload.is_a?(String)
+
+          Legion::JSON.parse(@payload)
+        rescue StandardError
+          @payload
+        end
+
+        def to_s
+          "#{topic}[#{partition}]@#{offset}"
+        end
+
+        def inspect
+          "#<#{self.class} topic=#{topic} partition=#{partition} offset=#{offset}>"
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/transport/kafka/producer.rb
+++ b/lib/legion/transport/kafka/producer.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require_relative 'defaults'
+
+module Legion
+  module Transport
+    module Kafka
+      # Wraps an rdkafka producer with connection lifecycle management.
+      # The underlying producer handle is lazily created on first use and
+      # shared across calls (rdkafka producers are thread-safe).
+      module Producer
+        class << self
+          # Publish a message to a Kafka topic.
+          #
+          # @param topic     [String]
+          # @param payload   [String, Hash] Hash values are JSON-encoded
+          # @param key       [String, nil]  partition key
+          # @param headers   [Hash]         Kafka message headers
+          # @param partition [Integer, nil] explicit partition; nil = librdkafka auto-assign
+          # @return [Hash] { topic:, partition:, offset: }
+          def publish(topic, payload, key: nil, headers: {}, partition: nil)
+            encoded = encode(payload)
+            delivery_handle = produce_message(topic, encoded, key:       key,
+                                                              headers:   stringify_headers(headers),
+                                                              partition: partition)
+            report = delivery_handle.wait(max_wait_timeout: delivery_timeout)
+            log_publish(topic, key, report)
+            { topic: report.topic_name, partition: report.partition, offset: report.offset }
+          rescue Legion::Transport::Kafka::PublishError
+            raise
+          rescue StandardError => e
+            raise Legion::Transport::Kafka::PublishError, "Kafka publish to #{topic} failed: #{e.message}"
+          end
+
+          # Close the underlying producer and flush any in-flight messages.
+          def reset!
+            @mutex&.synchronize do
+              @producer&.close
+              @producer = nil
+            end
+          end
+
+          private
+
+          def produce_message(topic, payload, key:, headers:, partition:)
+            opts = { topic: topic, payload: payload }
+            opts[:key]       = key       unless key.nil?
+            opts[:headers]   = headers   unless headers.empty?
+            opts[:partition] = partition unless partition.nil?
+            handle(opts)
+          rescue StandardError => e
+            raise Legion::Transport::Kafka::PublishError, e.message
+          end
+
+          def handle(opts)
+            producer.produce(**opts)
+          end
+
+          def producer
+            mutex.synchronize do
+              @producer ||= build_producer
+            end
+          end
+
+          def mutex
+            @mutex ||= Mutex.new
+          end
+
+          def build_producer
+            config = producer_config
+            ::Rdkafka::Config.new(config).producer
+          end
+
+          def producer_config
+            settings   = Legion::Transport::Kafka.kafka_settings
+            p_settings = settings[:producer] || DEFAULTS[:producer]
+            brokers    = Array(settings[:brokers]).join(',')
+
+            cfg = {
+              'bootstrap.servers'  => brokers,
+              'acks'               => (p_settings[:acks] || 'all').to_s,
+              'retries'            => (p_settings[:retries] || 3).to_i,
+              'retry.backoff.ms'   => (p_settings[:retry_backoff_ms] || 100).to_i,
+              'message.timeout.ms' => (p_settings[:message_timeout_ms] || 30_000).to_i,
+              'compression.codec'  => (p_settings[:compression] || 'none').to_s,
+              'batch.size'         => (p_settings[:batch_size] || 100).to_i,
+              'linger.ms'          => (p_settings[:linger_ms] || 5).to_i
+            }
+
+            apply_security!(cfg, settings[:security] || DEFAULTS[:security])
+            cfg
+          end
+
+          def apply_security!(cfg, sec)
+            protocol = (sec[:protocol] || 'plaintext').to_s
+            cfg['security.protocol'] = protocol
+            return if protocol == 'plaintext'
+
+            if sec[:sasl_mechanism].to_s != ''
+              cfg['sasl.mechanism'] = sec[:sasl_mechanism].to_s
+              cfg['sasl.username']  = sec[:sasl_username].to_s
+              cfg['sasl.password']  = sec[:sasl_password].to_s
+            end
+
+            cfg['ssl.ca.location']          = sec[:ssl_ca_cert_path].to_s          if sec[:ssl_ca_cert_path].to_s != ''
+            cfg['ssl.certificate.location'] = sec[:ssl_client_cert_path].to_s      if sec[:ssl_client_cert_path].to_s != ''
+            cfg['ssl.key.location']         = sec[:ssl_client_cert_key_path].to_s  if sec[:ssl_client_cert_key_path].to_s != ''
+          end
+
+          def delivery_timeout
+            settings = Legion::Transport::Kafka.kafka_settings
+            ((settings[:producer] || DEFAULTS[:producer])[:message_timeout_ms] || 30_000) / 1_000.0
+          end
+
+          def encode(payload)
+            return payload if payload.is_a?(String)
+
+            Legion::JSON.dump(payload)
+          rescue StandardError
+            payload.to_s
+          end
+
+          def stringify_headers(headers)
+            headers.transform_keys(&:to_s).transform_values(&:to_s)
+          end
+
+          def log_publish(topic, key, report)
+            return unless defined?(Legion::Logging)
+
+            Legion::Logging.debug(
+              "Kafka published topic=#{topic} partition=#{report.partition} " \
+              "offset=#{report.offset}#{" key=#{key}" if key}"
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/transport/settings.rb
+++ b/lib/legion/transport/settings.rb
@@ -97,6 +97,15 @@ module Legion
         }
       end
 
+      def self.kafka
+        require_relative 'kafka/defaults'
+        Legion::Transport::Kafka::DEFAULTS.dup.tap do |k|
+          k[:enabled] = ENV['transport.kafka.enabled'] == 'true'
+          k[:brokers] = ENV['transport.kafka.brokers'].split(',').map(&:strip) if ENV['transport.kafka.brokers']
+          k[:consumer_group] = ENV['transport.kafka.consumer_group'] if ENV['transport.kafka.consumer_group']
+        end
+      end
+
       def self.default
         cluster_csv = ENV.fetch('transport.cluster_nodes', '')
         {
@@ -110,6 +119,7 @@ module Legion
           connection:           connection,
           channel:              channel,
           tenant_topology:      tenant_topology,
+          kafka:                kafka,
           cluster_nodes:        cluster_csv.empty? ? [] : cluster_csv.split(',').map(&:strip),
           connection_pool_size: (ENV['transport.connection_pool_size'] || 1).to_i,
           max_payload_bytes:    (ENV['transport.max_payload_bytes'] || 1_048_576).to_i,

--- a/lib/legion/transport/version.rb
+++ b/lib/legion/transport/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Transport
-    VERSION = '1.4.7'
+    VERSION = '1.4.8'
   end
 end

--- a/spec/legion/transport/kafka_spec.rb
+++ b/spec/legion/transport/kafka_spec.rb
@@ -1,0 +1,561 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'legion/transport/kafka'
+
+# All rdkafka interaction is mocked — no broker required.
+RSpec.describe Legion::Transport::Kafka do
+  # ---------------------------------------------------------------------------
+  # Helpers / shared doubles
+  # ---------------------------------------------------------------------------
+  let(:delivery_report) do
+    instance_double('Rdkafka::Producer::DeliveryReport',
+                    topic_name: 'test.topic',
+                    partition:  0,
+                    offset:     42)
+  end
+
+  let(:delivery_handle) do
+    handle = instance_double('Rdkafka::Producer::DeliveryHandle')
+    allow(handle).to receive(:wait).and_return(delivery_report)
+    handle
+  end
+
+  let(:rdkafka_producer) do
+    prod = instance_double('Rdkafka::Producer')
+    allow(prod).to receive(:produce).and_return(delivery_handle)
+    allow(prod).to receive(:close)
+    prod
+  end
+
+  let(:raw_message) do
+    instance_double('Rdkafka::Consumer::Message',
+                    topic:     'test.topic',
+                    partition: 0,
+                    offset:    0,
+                    key:       nil,
+                    headers:   {},
+                    timestamp: Time.now,
+                    payload:   '{"event":"test"}')
+  end
+
+  let(:rdkafka_consumer) do
+    consumer = instance_double('Rdkafka::Consumer')
+    allow(consumer).to receive(:subscribe)
+    allow(consumer).to receive(:poll).and_return(raw_message, nil)
+    allow(consumer).to receive(:commit)
+    allow(consumer).to receive(:close)
+    consumer
+  end
+
+  let(:rdkafka_config) do
+    cfg = instance_double('Rdkafka::Config')
+    allow(cfg).to receive(:producer).and_return(rdkafka_producer)
+    allow(cfg).to receive(:consumer).and_return(rdkafka_consumer)
+    cfg
+  end
+
+  # Enable Kafka in settings and stub rdkafka require + Config.new for each example.
+  before do
+    Legion::Settings[:transport][:kafka] ||= {}
+    Legion::Settings[:transport][:kafka][:enabled] = true
+    Legion::Settings[:transport][:kafka][:brokers] = ['127.0.0.1:9092']
+
+    # Stub rdkafka at the require level so the gem doesn't need to be installed.
+    allow(Legion::Transport::Kafka).to receive(:require_rdkafka)
+    stub_const('Rdkafka::Config', Class.new do
+      def self.new(_cfg)
+        # overridden per-example via allow_any_instance_of or instance_double
+        instance_double('Rdkafka::Config')
+      end
+    end)
+  end
+
+  after do
+    Legion::Transport::Kafka.reset!
+    Legion::Transport::Kafka::Producer.instance_variable_set(:@producer, nil)
+    Legion::Transport::Kafka::Producer.instance_variable_set(:@mutex, nil)
+    Legion::Settings[:transport][:kafka][:enabled] = false
+  end
+
+  # ---------------------------------------------------------------------------
+  # .enabled?
+  # ---------------------------------------------------------------------------
+  describe '.enabled?' do
+    it 'returns true when enabled and rdkafka is available' do
+      expect(described_class.enabled?).to be true
+    end
+
+    it 'returns false when disabled in settings' do
+      Legion::Settings[:transport][:kafka][:enabled] = false
+      expect(described_class.enabled?).to be false
+    end
+
+    it 'returns false when rdkafka gem is missing' do
+      allow(described_class).to receive(:require_rdkafka)
+        .and_raise(Legion::Transport::Kafka::UnavailableError)
+      expect(described_class.enabled?).to be false
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # .brokers / .default_group
+  # ---------------------------------------------------------------------------
+  describe '.brokers' do
+    it 'returns the configured broker list' do
+      expect(described_class.brokers).to eq(['127.0.0.1:9092'])
+    end
+  end
+
+  describe '.default_group' do
+    it 'returns the configured consumer group' do
+      Legion::Settings[:transport][:kafka][:consumer_group] = 'my-group'
+      expect(described_class.default_group).to eq('my-group')
+    end
+
+    it 'defaults to "legion" when not configured' do
+      Legion::Settings[:transport][:kafka].delete(:consumer_group)
+      expect(described_class.default_group).to eq('legion')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # .kafka_settings fallback
+  # ---------------------------------------------------------------------------
+  describe '.kafka_settings' do
+    it 'falls back to DEFAULTS when Settings raises' do
+      original = Legion::Settings[:transport]
+      call_count = 0
+      allow(Legion::Settings).to receive(:[]) do |key|
+        call_count += 1
+        raise StandardError if key == :transport && call_count == 1
+
+        original
+      end
+      result = described_class.kafka_settings
+      # Returns DEFAULTS hash when Settings access fails
+      expect(result[:enabled]).to be false
+      expect(result).to have_key(:brokers)
+      expect(result).to have_key(:producer)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # .publish (delegates to Producer)
+  # ---------------------------------------------------------------------------
+  describe '.publish' do
+    before do
+      allow(Rdkafka::Config).to receive(:new).and_return(rdkafka_config)
+      allow(rdkafka_config).to receive(:producer).and_return(rdkafka_producer)
+    end
+
+    it 'raises DisabledError when Kafka is disabled' do
+      Legion::Settings[:transport][:kafka][:enabled] = false
+      expect { described_class.publish('topic', 'msg') }
+        .to raise_error(Legion::Transport::Kafka::DisabledError)
+    end
+
+    it 'raises UnavailableError when rdkafka gem is missing' do
+      allow(described_class).to receive(:require_rdkafka)
+        .and_raise(Legion::Transport::Kafka::UnavailableError, 'not installed')
+      expect { described_class.publish('topic', 'msg') }
+        .to raise_error(Legion::Transport::Kafka::UnavailableError)
+    end
+
+    it 'delegates to Producer.publish and returns delivery metadata' do
+      allow(Legion::Transport::Kafka::Producer).to receive(:publish)
+        .with('test.topic', '{"x":1}', key: nil, headers: {}, partition: nil)
+        .and_return({ topic: 'test.topic', partition: 0, offset: 42 })
+
+      result = described_class.publish('test.topic', '{"x":1}')
+      expect(result[:topic]).to eq('test.topic')
+      expect(result[:offset]).to eq(42)
+    end
+
+    it 'forwards key and headers' do
+      allow(Legion::Transport::Kafka::Producer).to receive(:publish)
+        .with('t', 'val', key: 'k1', headers: { 'h' => 'v' }, partition: nil)
+        .and_return({ topic: 't', partition: 0, offset: 1 })
+
+      result = described_class.publish('t', 'val', key: 'k1', headers: { 'h' => 'v' })
+      expect(result[:topic]).to eq('t')
+    end
+
+    it 'forwards explicit partition' do
+      allow(Legion::Transport::Kafka::Producer).to receive(:publish)
+        .with('t', 'val', key: nil, headers: {}, partition: 3)
+        .and_return({ topic: 't', partition: 3, offset: 0 })
+
+      result = described_class.publish('t', 'val', partition: 3)
+      expect(result[:partition]).to eq(3)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # .subscribe (delegates to Consumer)
+  # ---------------------------------------------------------------------------
+  describe '.subscribe' do
+    it 'raises DisabledError when Kafka is disabled' do
+      Legion::Settings[:transport][:kafka][:enabled] = false
+      expect { described_class.subscribe('topic') { |_m| nil } }
+        .to raise_error(Legion::Transport::Kafka::DisabledError)
+    end
+
+    it 'delegates to Consumer.subscribe with defaults' do
+      allow(Legion::Transport::Kafka::Consumer).to receive(:subscribe)
+        .with('test.topic', group: 'legion', from_beginning: false, max_messages: nil)
+        .and_yield(instance_double('Legion::Transport::Kafka::IncomingMessage'))
+
+      received = []
+      described_class.subscribe('test.topic', group: 'legion') { |m| received << m }
+      expect(received.size).to eq(1)
+    end
+
+    it 'passes max_messages to Consumer' do
+      allow(Legion::Transport::Kafka::Consumer).to receive(:subscribe)
+        .with('t', group: 'g', from_beginning: true, max_messages: 5)
+
+      described_class.subscribe('t', group: 'g', from_beginning: true, max_messages: 5) { |_m| nil }
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # .replay (delegates to Consumer)
+  # ---------------------------------------------------------------------------
+  describe '.replay' do
+    it 'raises DisabledError when Kafka is disabled' do
+      Legion::Settings[:transport][:kafka][:enabled] = false
+      expect { described_class.replay('topic') { |_m| nil } }
+        .to raise_error(Legion::Transport::Kafka::DisabledError)
+    end
+
+    it 'delegates to Consumer.replay with from_beginning: true by default' do
+      allow(Legion::Transport::Kafka::Consumer).to receive(:replay) do |topic, **opts, &_block|
+        expect(topic).to eq('test.topic')
+        expect(opts[:from_beginning]).to be true
+      end
+
+      described_class.replay('test.topic') { |_m| nil }
+    end
+
+    it 'passes from_offset when provided' do
+      allow(Legion::Transport::Kafka::Consumer).to receive(:replay) do |_topic, **opts, &_block|
+        expect(opts[:from_offset]).to eq(100)
+      end
+
+      described_class.replay('test.topic', from_offset: 100) { |_m| nil }
+    end
+
+    it 'passes from_timestamp when provided' do
+      ts = Time.now
+      allow(Legion::Transport::Kafka::Consumer).to receive(:replay) do |_topic, **opts, &_block|
+        expect(opts[:from_timestamp]).to eq(ts)
+      end
+
+      described_class.replay('test.topic', from_timestamp: ts) { |_m| nil }
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # .ensure_topic (delegates to Admin)
+  # ---------------------------------------------------------------------------
+  describe '.ensure_topic' do
+    it 'raises DisabledError when Kafka is disabled' do
+      Legion::Settings[:transport][:kafka][:enabled] = false
+      expect { described_class.ensure_topic('topic') }
+        .to raise_error(Legion::Transport::Kafka::DisabledError)
+    end
+
+    it 'delegates to Admin.ensure_topic' do
+      allow(Legion::Transport::Kafka::Admin).to receive(:ensure_topic)
+        .with('new.topic', partitions: 3, replication_factor: 2, config: {})
+        .and_return(true)
+
+      result = described_class.ensure_topic('new.topic', partitions: 3, replication_factor: 2)
+      expect(result).to be true
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Error classes
+  # ---------------------------------------------------------------------------
+  describe 'error hierarchy' do
+    it 'DisabledError is a StandardError' do
+      expect(Legion::Transport::Kafka::DisabledError.ancestors).to include(StandardError)
+    end
+
+    it 'UnavailableError is a StandardError' do
+      expect(Legion::Transport::Kafka::UnavailableError.ancestors).to include(StandardError)
+    end
+
+    it 'PublishError is a StandardError' do
+      expect(Legion::Transport::Kafka::PublishError.ancestors).to include(StandardError)
+    end
+
+    it 'ConsumerError is a StandardError' do
+      expect(Legion::Transport::Kafka::ConsumerError.ancestors).to include(StandardError)
+    end
+
+    it 'AdminError is a StandardError' do
+      expect(Legion::Transport::Kafka::AdminError.ancestors).to include(StandardError)
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Producer unit tests (isolated from the top-level Kafka module)
+# ---------------------------------------------------------------------------
+RSpec.describe Legion::Transport::Kafka::Producer do
+  let(:delivery_report) do
+    instance_double('Rdkafka::Producer::DeliveryReport',
+                    topic_name: 'test.topic',
+                    partition:  0,
+                    offset:     7)
+  end
+
+  let(:delivery_handle) do
+    handle = instance_double('Rdkafka::Producer::DeliveryHandle')
+    allow(handle).to receive(:wait).and_return(delivery_report)
+    handle
+  end
+
+  let(:rdkafka_producer) do
+    prod = instance_double('Rdkafka::Producer')
+    allow(prod).to receive(:produce).and_return(delivery_handle)
+    allow(prod).to receive(:close)
+    prod
+  end
+
+  let(:rdkafka_config) do
+    cfg = instance_double('Rdkafka::Config')
+    allow(cfg).to receive(:producer).and_return(rdkafka_producer)
+    cfg
+  end
+
+  before do
+    Legion::Settings[:transport][:kafka] ||= {}
+    Legion::Settings[:transport][:kafka][:enabled] = true
+    Legion::Settings[:transport][:kafka][:brokers] = ['127.0.0.1:9092']
+
+    # Stub the Rdkafka constant so specs don't need the native gem installed.
+    stub_const('Rdkafka', Module.new)
+    stub_const('Rdkafka::Config', Class.new)
+    stub_const('Rdkafka::Producer', Class.new)
+    stub_const('Rdkafka::Producer::DeliveryReport', Class.new)
+    stub_const('Rdkafka::Producer::DeliveryHandle', Class.new)
+    allow(Rdkafka::Config).to receive(:new).and_return(rdkafka_config)
+    described_class.instance_variable_set(:@producer, nil)
+    described_class.instance_variable_set(:@mutex, nil)
+  end
+
+  after do
+    described_class.reset!
+    described_class.instance_variable_set(:@producer, nil)
+    described_class.instance_variable_set(:@mutex, nil)
+    Legion::Settings[:transport][:kafka][:enabled] = false
+  end
+
+  describe '.publish' do
+    it 'returns topic, partition, offset on success' do
+      result = described_class.publish('test.topic', 'hello')
+      expect(result).to eq({ topic: 'test.topic', partition: 0, offset: 7 })
+    end
+
+    it 'JSON-encodes Hash payloads' do
+      expect(rdkafka_producer).to receive(:produce) do |**opts|
+        expect(opts[:payload]).to include('"event"')
+        delivery_handle
+      end
+      described_class.publish('test.topic', { event: 'login' })
+    end
+
+    it 'passes string payload unchanged' do
+      expect(rdkafka_producer).to receive(:produce) do |**opts|
+        expect(opts[:payload]).to eq('raw-string')
+        delivery_handle
+      end
+      described_class.publish('test.topic', 'raw-string')
+    end
+
+    it 'omits key from produce opts when nil' do
+      expect(rdkafka_producer).to receive(:produce) do |**opts|
+        expect(opts).not_to have_key(:key)
+        delivery_handle
+      end
+      described_class.publish('test.topic', 'msg', key: nil)
+    end
+
+    it 'includes key when provided' do
+      expect(rdkafka_producer).to receive(:produce) do |**opts|
+        expect(opts[:key]).to eq('mykey')
+        delivery_handle
+      end
+      described_class.publish('test.topic', 'msg', key: 'mykey')
+    end
+
+    it 'includes explicit partition when provided' do
+      expect(rdkafka_producer).to receive(:produce) do |**opts|
+        expect(opts[:partition]).to eq(2)
+        delivery_handle
+      end
+      described_class.publish('test.topic', 'msg', partition: 2)
+    end
+
+    it 'raises PublishError when rdkafka raises' do
+      allow(rdkafka_producer).to receive(:produce).and_raise(StandardError, 'broker down')
+      expect { described_class.publish('test.topic', 'msg') }
+        .to raise_error(Legion::Transport::Kafka::PublishError, /broker down/)
+    end
+
+    it 'stringifies header keys and values' do
+      expect(rdkafka_producer).to receive(:produce) do |**opts|
+        expect(opts[:headers]).to eq({ 'source' => 'legion', 'version' => '2' })
+        delivery_handle
+      end
+      described_class.publish('test.topic', 'msg', headers: { source: :legion, version: 2 })
+    end
+  end
+
+  describe '.reset!' do
+    it 'closes and clears the producer' do
+      described_class.instance_variable_set(:@producer, rdkafka_producer)
+      described_class.instance_variable_set(:@mutex, Mutex.new)
+      expect(rdkafka_producer).to receive(:close)
+      described_class.reset!
+      expect(described_class.instance_variable_get(:@producer)).to be_nil
+    end
+
+    it 'is safe to call when no producer exists' do
+      described_class.instance_variable_set(:@producer, nil)
+      expect { described_class.reset! }.not_to raise_error
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------
+# IncomingMessage unit tests
+# ---------------------------------------------------------------------------
+RSpec.describe Legion::Transport::Kafka::IncomingMessage do
+  let(:raw) do
+    instance_double('Rdkafka::Consumer::Message',
+                    topic:     'audit.events',
+                    partition: 1,
+                    offset:    99,
+                    key:       'user-42',
+                    headers:   { 'source' => 'legion' },
+                    timestamp: Time.at(1_700_000_000),
+                    payload:   '{"action":"login"}')
+  end
+
+  subject(:msg) { described_class.new(raw) }
+
+  it 'exposes topic' do
+    expect(msg.topic).to eq('audit.events')
+  end
+
+  it 'exposes partition' do
+    expect(msg.partition).to eq(1)
+  end
+
+  it 'exposes offset' do
+    expect(msg.offset).to eq(99)
+  end
+
+  it 'exposes key' do
+    expect(msg.key).to eq('user-42')
+  end
+
+  it 'exposes headers' do
+    expect(msg.headers).to eq({ 'source' => 'legion' })
+  end
+
+  it 'exposes timestamp' do
+    expect(msg.timestamp).to eq(Time.at(1_700_000_000))
+  end
+
+  it 'returns raw payload string' do
+    expect(msg.payload).to eq('{"action":"login"}')
+  end
+
+  it 'decoded_payload parses JSON' do
+    stub_const('Legion::JSON', Module.new do
+      def self.parse(str)
+        require 'json'
+        JSON.parse(str)
+      end
+    end)
+    expect(msg.decoded_payload).to eq({ 'action' => 'login' })
+  end
+
+  it 'decoded_payload returns raw string on parse failure' do
+    allow(raw).to receive(:payload).and_return('not-json{{{')
+    bad_msg = described_class.new(raw)
+    expect(bad_msg.decoded_payload).to eq('not-json{{{')
+  end
+
+  it 'to_s includes topic partition and offset' do
+    expect(msg.to_s).to eq('audit.events[1]@99')
+  end
+
+  it 'inspect includes class name and key fields' do
+    expect(msg.inspect).to include('IncomingMessage')
+    expect(msg.inspect).to include('audit.events')
+  end
+
+  it 'raw returns the original rdkafka message' do
+    expect(msg.raw).to be(raw)
+  end
+
+  context 'when headers is nil' do
+    let(:raw_no_headers) do
+      instance_double('Rdkafka::Consumer::Message',
+                      topic: 't', partition: 0, offset: 0,
+                      key: nil, headers: nil,
+                      timestamp: Time.now, payload: 'x')
+    end
+
+    it 'defaults headers to empty hash' do
+      expect(described_class.new(raw_no_headers).headers).to eq({})
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+RSpec.describe Legion::Transport::Kafka::DEFAULTS do
+  it 'is disabled by default' do
+    expect(described_class[:enabled]).to be false
+  end
+
+  it 'has a default broker' do
+    expect(described_class[:brokers]).not_to be_empty
+  end
+
+  it 'has a default consumer group' do
+    expect(described_class[:consumer_group]).not_to be_nil
+  end
+
+  it 'has producer defaults' do
+    expect(described_class[:producer]).to be_a(Hash)
+    expect(described_class[:producer]).to have_key(:acks)
+    expect(described_class[:producer]).to have_key(:retries)
+    expect(described_class[:producer]).to have_key(:compression)
+  end
+
+  it 'has consumer defaults' do
+    expect(described_class[:consumer]).to be_a(Hash)
+    expect(described_class[:consumer]).to have_key(:poll_timeout_ms)
+    expect(described_class[:consumer]).to have_key(:auto_offset_reset)
+  end
+
+  it 'has admin defaults' do
+    expect(described_class[:admin]).to be_a(Hash)
+    expect(described_class[:admin]).to have_key(:operation_timeout_ms)
+  end
+
+  it 'has security defaults' do
+    expect(described_class[:security]).to be_a(Hash)
+    expect(described_class[:security][:protocol]).to eq('plaintext')
+  end
+end


### PR DESCRIPTION
## Summary
- Self-registering transport routes module (v1.4.7)
- Optional Kafka adapter for event streaming alongside RabbitMQ (v1.4.8)
- Dedicated sessions for isolated AMQP connections
- Copilot review fixes

## Test plan
- 518 examples, 0 failures
- 0 rubocop offenses