### PR TITLE
add credential scoping transport passive declares (phase 5 group 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+## [1.4.16] - 2026-04-07
+
+### Added
+- `Exchange#passive?` — mode-aware passive declare: returns false when `dynamic_rmq_creds` is disabled (default), true during bootstrap phase, false for infra/agent after identity resolves, true for worker mode (credential scoping phase 5)
+- `Queue#passive?` — same mode-aware logic for queues, with worker own-queue exception (workers actively declare their own queues)
+- `Queue#own_queue?` — checks `Identity::Process.queue_prefix` to determine if a queue belongs to this process; workers can actively declare own queues but passively assert shared queues
+- `Exchange#credential_scoping_enabled?`, `Exchange#bootstrap_phase?`, `Exchange#topology_mode?` — private helpers with `defined?` guards for optional dependencies
+- `Queue#credential_scoping_enabled?`, `Queue#bootstrap_phase?`, `Queue#topology_mode?` — same private helpers on Queue
+- Passive declare strips queue arguments (`x-dead-letter-exchange`, `x-queue-type`) to avoid `PreconditionFailed` on argument mismatch
+- `ensure_dlx` skips DLX creation when `credential_scoping_enabled? && (bootstrap_phase? || !topology_mode?)` — only infra/agent create shared DLX topology
+- `PreconditionFailed` guard on Exchange and Queue: worker and bootstrap modes raise instead of deleting and recreating shared topology
+
 ## [1.4.15] - 2026-04-06
 
 ### Added

--- a/lib/legion/transport/exchange.rb
+++ b/lib/legion/transport/exchange.rb
@@ -41,7 +41,7 @@ module Legion
       rescue Legion::Transport::CONNECTOR::PreconditionFailed, Legion::Transport::CONNECTOR::ChannelAlreadyClosed => e
         handle_exception(e, level: :warn, handled: true, operation: 'transport.exchange.initialize', exchange: exchange)
         raise unless @retries.nil?
-        raise if credential_scoping_enabled? && !topology_mode?
+        raise if credential_scoping_enabled? && (bootstrap_phase? || (!topology_mode? && Legion::Identity::Process.resolved?))
 
         @retries = 1
         # Only close the channel if it was not explicitly provided by the caller.

--- a/lib/legion/transport/exchange.rb
+++ b/lib/legion/transport/exchange.rb
@@ -41,6 +41,7 @@ module Legion
       rescue Legion::Transport::CONNECTOR::PreconditionFailed, Legion::Transport::CONNECTOR::ChannelAlreadyClosed => e
         handle_exception(e, level: :warn, handled: true, operation: 'transport.exchange.initialize', exchange: exchange)
         raise unless @retries.nil?
+        raise if credential_scoping_enabled? && !topology_mode?
 
         @retries = 1
         # Only close the channel if it was not explicitly provided by the caller.
@@ -65,7 +66,11 @@ module Legion
       end
 
       def passive?
-        false
+        return false unless credential_scoping_enabled?
+        return true  if bootstrap_phase?
+        return false if topology_mode?
+
+        true
       end
 
       def exchange_name
@@ -103,6 +108,24 @@ module Legion
       end
 
       private
+
+      def credential_scoping_enabled?
+        return false unless defined?(Legion::Settings)
+
+        Legion::Settings.dig(:crypt, :vault, :dynamic_rmq_creds) == true
+      end
+
+      def bootstrap_phase?
+        return false unless defined?(Legion::Identity::Process)
+
+        !Legion::Identity::Process.resolved? && credential_scoping_enabled?
+      end
+
+      def topology_mode?
+        return true unless defined?(Legion::Mode)
+
+        Legion::Mode.infra? || Legion::Mode.agent?
+      end
 
       def safely_close_channel(error_channel)
         error_channel&.close if error_channel&.open?

--- a/lib/legion/transport/exchange.rb
+++ b/lib/legion/transport/exchange.rb
@@ -67,6 +67,7 @@ module Legion
 
       def passive?
         return false unless credential_scoping_enabled?
+        return false unless defined?(Legion::Identity::Process)
         return true  if bootstrap_phase?
         return false if topology_mode?
 

--- a/lib/legion/transport/queue.rb
+++ b/lib/legion/transport/queue.rb
@@ -14,7 +14,8 @@ module Legion
         super(channel, queue, merged)
       rescue Legion::Transport::CONNECTOR::PreconditionFailed => e
         handle_exception(e, level: :warn, handled: true, operation: 'transport.queue.initialize', queue: queue)
-        raise if credential_scoping_enabled? && (bootstrap_phase? || (!topology_mode? && !own_queue?))
+        identity_resolved = defined?(Legion::Identity::Process) && Legion::Identity::Process.resolved?
+        raise if credential_scoping_enabled? && (bootstrap_phase? || (!topology_mode? && identity_resolved && !own_queue?))
 
         retries.zero? ? retries = 1 : raise
         recreate_queue(queue)
@@ -39,8 +40,9 @@ module Legion
         hash[:exclusive] = false
         hash[:block] = false
         hash[:auto_delete] = false
-        hash[:passive] = passive?
-        if passive?
+        is_passive = passive?
+        hash[:passive] = is_passive
+        if is_passive
           hash[:arguments] = {}
         else
           args = { 'x-queue-type': 'quorum' }
@@ -52,6 +54,7 @@ module Legion
 
       def passive?
         return false unless credential_scoping_enabled?
+        return false unless defined?(Legion::Identity::Process)
         return true  if bootstrap_phase?
         return false if topology_mode?
         return false if own_queue?

--- a/lib/legion/transport/queue.rb
+++ b/lib/legion/transport/queue.rb
@@ -7,12 +7,15 @@ module Legion
 
       def initialize(queue = queue_name, options = {})
         retries ||= 0
+        @queue_name_arg = queue
         @options = options
         merged = options_builder(default_options, queue_options, options)
         ensure_dlx(merged)
         super(channel, queue, merged)
       rescue Legion::Transport::CONNECTOR::PreconditionFailed => e
         handle_exception(e, level: :warn, handled: true, operation: 'transport.queue.initialize', queue: queue)
+        raise if credential_scoping_enabled? && (bootstrap_phase? || (!topology_mode? && !own_queue?))
+
         retries.zero? ? retries = 1 : raise
         recreate_queue(queue)
         safely_close_channel(@channel)
@@ -36,10 +39,33 @@ module Legion
         hash[:exclusive] = false
         hash[:block] = false
         hash[:auto_delete] = false
-        args = { 'x-queue-type': 'quorum' }
-        args[:'x-dead-letter-exchange'] = dlx_exchange_name if dlx_enabled
-        hash[:arguments] = args
+        hash[:passive] = passive?
+        if passive?
+          hash[:arguments] = {}
+        else
+          args = { 'x-queue-type': 'quorum' }
+          args[:'x-dead-letter-exchange'] = dlx_exchange_name if dlx_enabled
+          hash[:arguments] = args
+        end
         hash
+      end
+
+      def passive?
+        return false unless credential_scoping_enabled?
+        return true  if bootstrap_phase?
+        return false if topology_mode?
+        return false if own_queue?
+
+        true
+      end
+
+      def own_queue?
+        return false unless defined?(Legion::Identity::Process) && Legion::Identity::Process.resolved?
+
+        prefix = Legion::Identity::Process.queue_prefix
+        return false if prefix.nil? || prefix.empty?
+
+        @queue_name_arg.to_s.start_with?(prefix)
       end
 
       def queue_options
@@ -55,6 +81,8 @@ module Legion
       end
 
       def ensure_dlx(merged_options)
+        return if credential_scoping_enabled? && (bootstrap_phase? || !topology_mode?)
+
         dlx_name = merged_options.dig(:arguments, :'x-dead-letter-exchange')
         return if dlx_name.nil? || dlx_name.empty?
 
@@ -87,6 +115,24 @@ module Legion
       end
 
       private
+
+      def credential_scoping_enabled?
+        return false unless defined?(Legion::Settings)
+
+        Legion::Settings.dig(:crypt, :vault, :dynamic_rmq_creds) == true
+      end
+
+      def bootstrap_phase?
+        return false unless defined?(Legion::Identity::Process)
+
+        !Legion::Identity::Process.resolved? && credential_scoping_enabled?
+      end
+
+      def topology_mode?
+        return true unless defined?(Legion::Mode)
+
+        Legion::Mode.infra? || Legion::Mode.agent?
+      end
 
       def safely_close_channel(tmp_channel)
         tmp_channel&.close if tmp_channel&.open?

--- a/lib/legion/transport/version.rb
+++ b/lib/legion/transport/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Transport
-    VERSION = '1.4.15'
+    VERSION = '1.4.16'
   end
 end

--- a/spec/legion/transport/exchange_passive_spec.rb
+++ b/spec/legion/transport/exchange_passive_spec.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Exchange passive declares (credential scoping)' do
+  # Use allocate to bypass AMQP initialization
+  let(:instance) { Legion::Transport::Exchange.allocate }
+
+  # Helper to configure Legion::Settings stub for dynamic_rmq_creds
+  def stub_settings(enabled)
+    allow(Legion::Settings).to receive(:dig).with(:crypt, :vault, :dynamic_rmq_creds).and_return(enabled ? true : false)
+  end
+
+  # Helper to stub Legion::Mode
+  def stub_mode(infra: false, agent: false)
+    mode = Module.new
+    mode.define_singleton_method(:infra?) { infra }
+    mode.define_singleton_method(:agent?) { agent }
+    stub_const('Legion::Mode', mode)
+  end
+
+  # Helper to stub Legion::Identity::Process
+  def stub_identity(resolved:)
+    process = Module.new
+    process.define_singleton_method(:resolved?) { resolved }
+    stub_const('Legion::Identity', Module.new)
+    stub_const('Legion::Identity::Process', process)
+  end
+
+  describe '#credential_scoping_enabled?' do
+    it 'returns false when Legion::Settings is not defined' do
+      hide_const('Legion::Settings')
+      expect(instance.send(:credential_scoping_enabled?)).to be false
+    end
+
+    it 'returns false when dynamic_rmq_creds is false' do
+      stub_settings(false)
+      expect(instance.send(:credential_scoping_enabled?)).to be false
+    end
+
+    it 'returns true when dynamic_rmq_creds is true' do
+      stub_settings(true)
+      expect(instance.send(:credential_scoping_enabled?)).to be true
+    end
+  end
+
+  describe '#bootstrap_phase?' do
+    it 'returns false when Legion::Identity::Process is not defined' do
+      stub_settings(true)
+      hide_const('Legion::Identity::Process') if defined?(Legion::Identity::Process)
+      expect(instance.send(:bootstrap_phase?)).to be false
+    end
+
+    it 'returns false when credential scoping is disabled' do
+      stub_settings(false)
+      stub_identity(resolved: false)
+      expect(instance.send(:bootstrap_phase?)).to be false
+    end
+
+    it 'returns true when scoping enabled and identity not resolved' do
+      stub_settings(true)
+      stub_identity(resolved: false)
+      expect(instance.send(:bootstrap_phase?)).to be true
+    end
+
+    it 'returns false when scoping enabled and identity is resolved' do
+      stub_settings(true)
+      stub_identity(resolved: true)
+      expect(instance.send(:bootstrap_phase?)).to be false
+    end
+  end
+
+  describe '#topology_mode?' do
+    it 'returns true when Legion::Mode is not defined (default safe)' do
+      hide_const('Legion::Mode') if defined?(Legion::Mode)
+      expect(instance.send(:topology_mode?)).to be true
+    end
+
+    it 'returns true for infra mode' do
+      stub_mode(infra: true, agent: false)
+      expect(instance.send(:topology_mode?)).to be true
+    end
+
+    it 'returns true for agent mode' do
+      stub_mode(infra: false, agent: true)
+      expect(instance.send(:topology_mode?)).to be true
+    end
+
+    it 'returns false for worker mode (neither infra nor agent)' do
+      stub_mode(infra: false, agent: false)
+      expect(instance.send(:topology_mode?)).to be false
+    end
+  end
+
+  describe '#passive?' do
+    context 'when credential scoping is disabled (default)' do
+      before { stub_settings(false) }
+
+      it 'returns false regardless of mode' do
+        stub_mode(infra: false, agent: false)
+        expect(instance.passive?).to be false
+      end
+
+      it 'returns false even without Legion::Mode defined' do
+        hide_const('Legion::Mode') if defined?(Legion::Mode)
+        expect(instance.passive?).to be false
+      end
+    end
+
+    context 'when credential scoping is enabled' do
+      before { stub_settings(true) }
+
+      it 'returns true during bootstrap phase (identity not resolved)' do
+        stub_identity(resolved: false)
+        stub_mode(infra: true, agent: false)
+        expect(instance.passive?).to be true
+      end
+
+      it 'returns false for infra mode after identity resolves' do
+        stub_identity(resolved: true)
+        stub_mode(infra: true, agent: false)
+        expect(instance.passive?).to be false
+      end
+
+      it 'returns false for agent mode after identity resolves' do
+        stub_identity(resolved: true)
+        stub_mode(infra: false, agent: true)
+        expect(instance.passive?).to be false
+      end
+
+      it 'returns true for worker mode after identity resolves' do
+        stub_identity(resolved: true)
+        stub_mode(infra: false, agent: false)
+        expect(instance.passive?).to be true
+      end
+
+      it 'returns true during bootstrap even for infra mode (bootstrap creds have configure: "")' do
+        stub_identity(resolved: false)
+        stub_mode(infra: true, agent: false)
+        expect(instance.passive?).to be true
+      end
+    end
+  end
+
+  describe '#default_options' do
+    it 'sets passive: false when scoping disabled' do
+      stub_settings(false)
+      opts = instance.default_options
+      expect(opts[:passive]).to be false
+    end
+
+    it 'sets passive: true for worker mode with scoping enabled' do
+      stub_settings(true)
+      stub_identity(resolved: true)
+      stub_mode(infra: false, agent: false)
+      opts = instance.default_options
+      expect(opts[:passive]).to be true
+    end
+
+    it 'sets passive: false for infra mode post-identity with scoping enabled' do
+      stub_settings(true)
+      stub_identity(resolved: true)
+      stub_mode(infra: true, agent: false)
+      opts = instance.default_options
+      expect(opts[:passive]).to be false
+    end
+
+    it 'always includes durable and auto_delete keys' do
+      stub_settings(false)
+      opts = instance.default_options
+      expect(opts).to have_key(:durable)
+      expect(opts).to have_key(:auto_delete)
+    end
+  end
+end

--- a/spec/legion/transport/queue_passive_spec.rb
+++ b/spec/legion/transport/queue_passive_spec.rb
@@ -1,0 +1,296 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Queue passive declares (credential scoping)' do
+  let(:instance) { Legion::Transport::Queue.allocate }
+
+  def stub_settings(enabled)
+    allow(Legion::Settings).to receive(:dig).with(:crypt, :vault, :dynamic_rmq_creds).and_return(enabled ? true : false)
+  end
+
+  def stub_mode(infra: false, agent: false)
+    mode = Module.new
+    mode.define_singleton_method(:infra?) { infra }
+    mode.define_singleton_method(:agent?) { agent }
+    stub_const('Legion::Mode', mode)
+  end
+
+  def stub_identity(resolved:, queue_prefix: nil)
+    prefix = queue_prefix
+    process = Module.new
+    process.define_singleton_method(:resolved?) { resolved }
+    process.define_singleton_method(:queue_prefix) { prefix }
+    stub_const('Legion::Identity', Module.new)
+    stub_const('Legion::Identity::Process', process)
+  end
+
+  describe '#credential_scoping_enabled?' do
+    it 'returns false when Legion::Settings is not defined' do
+      hide_const('Legion::Settings')
+      expect(instance.send(:credential_scoping_enabled?)).to be false
+    end
+
+    it 'returns false when dynamic_rmq_creds is false' do
+      stub_settings(false)
+      expect(instance.send(:credential_scoping_enabled?)).to be false
+    end
+
+    it 'returns true when dynamic_rmq_creds is true' do
+      stub_settings(true)
+      expect(instance.send(:credential_scoping_enabled?)).to be true
+    end
+  end
+
+  describe '#bootstrap_phase?' do
+    it 'returns false when credential scoping is disabled' do
+      stub_settings(false)
+      stub_identity(resolved: false)
+      expect(instance.send(:bootstrap_phase?)).to be false
+    end
+
+    it 'returns true when scoping enabled and identity not resolved' do
+      stub_settings(true)
+      stub_identity(resolved: false)
+      expect(instance.send(:bootstrap_phase?)).to be true
+    end
+
+    it 'returns false when scoping enabled and identity is resolved' do
+      stub_settings(true)
+      stub_identity(resolved: true)
+      expect(instance.send(:bootstrap_phase?)).to be false
+    end
+  end
+
+  describe '#topology_mode?' do
+    it 'returns true when Legion::Mode is not defined' do
+      hide_const('Legion::Mode') if defined?(Legion::Mode)
+      expect(instance.send(:topology_mode?)).to be true
+    end
+
+    it 'returns true for infra mode' do
+      stub_mode(infra: true, agent: false)
+      expect(instance.send(:topology_mode?)).to be true
+    end
+
+    it 'returns true for agent mode' do
+      stub_mode(infra: false, agent: true)
+      expect(instance.send(:topology_mode?)).to be true
+    end
+
+    it 'returns false for worker mode' do
+      stub_mode(infra: false, agent: false)
+      expect(instance.send(:topology_mode?)).to be false
+    end
+  end
+
+  describe '#own_queue?' do
+    before { instance.instance_variable_set(:@queue_name_arg, 'worker.myapp.queue1') }
+
+    it 'returns false when Legion::Identity::Process is not defined' do
+      hide_const('Legion::Identity::Process') if defined?(Legion::Identity::Process)
+      hide_const('Legion::Identity') if defined?(Legion::Identity)
+      expect(instance.own_queue?).to be false
+    end
+
+    it 'returns false when identity is not resolved' do
+      stub_identity(resolved: false, queue_prefix: 'worker.myapp')
+      expect(instance.own_queue?).to be false
+    end
+
+    it 'returns false when prefix is nil' do
+      stub_identity(resolved: true, queue_prefix: nil)
+      expect(instance.own_queue?).to be false
+    end
+
+    it 'returns false when prefix is empty' do
+      stub_identity(resolved: true, queue_prefix: '')
+      expect(instance.own_queue?).to be false
+    end
+
+    it 'returns true when queue name starts with own prefix' do
+      stub_identity(resolved: true, queue_prefix: 'worker.myapp')
+      expect(instance.own_queue?).to be true
+    end
+
+    it 'returns false when queue name does not start with own prefix' do
+      stub_identity(resolved: true, queue_prefix: 'worker.other')
+      expect(instance.own_queue?).to be false
+    end
+
+    it 'returns false for shared extension queue (e.g. github.repos)' do
+      instance.instance_variable_set(:@queue_name_arg, 'github.repos')
+      stub_identity(resolved: true, queue_prefix: 'worker.myapp')
+      expect(instance.own_queue?).to be false
+    end
+  end
+
+  describe '#passive?' do
+    context 'when credential scoping is disabled (default)' do
+      before { stub_settings(false) }
+
+      it 'returns false regardless of mode' do
+        stub_mode(infra: false, agent: false)
+        expect(instance.passive?).to be false
+      end
+    end
+
+    context 'when credential scoping is enabled' do
+      before { stub_settings(true) }
+
+      it 'returns true during bootstrap phase' do
+        stub_identity(resolved: false)
+        stub_mode(infra: true, agent: false)
+        expect(instance.passive?).to be true
+      end
+
+      it 'returns false for infra mode after identity resolves' do
+        stub_identity(resolved: true)
+        stub_mode(infra: true, agent: false)
+        expect(instance.passive?).to be false
+      end
+
+      it 'returns false for agent mode after identity resolves' do
+        stub_identity(resolved: true)
+        stub_mode(infra: false, agent: true)
+        expect(instance.passive?).to be false
+      end
+
+      it 'returns true for worker mode on shared queue' do
+        instance.instance_variable_set(:@queue_name_arg, 'github.repos')
+        stub_identity(resolved: true, queue_prefix: 'worker.myapp')
+        stub_mode(infra: false, agent: false)
+        expect(instance.passive?).to be true
+      end
+
+      it 'returns false for worker mode on its own queue' do
+        instance.instance_variable_set(:@queue_name_arg, 'worker.myapp.queue1')
+        stub_identity(resolved: true, queue_prefix: 'worker.myapp')
+        stub_mode(infra: false, agent: false)
+        expect(instance.passive?).to be false
+      end
+
+      it 'returns true during bootstrap even for infra mode' do
+        stub_identity(resolved: false)
+        stub_mode(infra: true, agent: false)
+        expect(instance.passive?).to be true
+      end
+    end
+  end
+
+  describe '#default_options' do
+    context 'when credential scoping is disabled' do
+      before { stub_settings(false) }
+
+      it 'includes x-queue-type and x-dead-letter-exchange arguments' do
+        opts = instance.default_options
+        expect(opts[:arguments]).to have_key(:'x-queue-type')
+        expect(opts[:arguments]).to have_key(:'x-dead-letter-exchange')
+        expect(opts[:passive]).to be false
+      end
+    end
+
+    context 'when passive (worker with scoping enabled)' do
+      before do
+        stub_settings(true)
+        stub_identity(resolved: true, queue_prefix: 'worker.myapp')
+        stub_mode(infra: false, agent: false)
+        instance.instance_variable_set(:@queue_name_arg, 'github.repos')
+      end
+
+      it 'sets passive: true' do
+        expect(instance.default_options[:passive]).to be true
+      end
+
+      it 'strips x-dead-letter-exchange argument' do
+        opts = instance.default_options
+        expect(opts[:arguments]).not_to have_key(:'x-dead-letter-exchange')
+      end
+
+      it 'strips x-queue-type argument' do
+        opts = instance.default_options
+        expect(opts[:arguments]).not_to have_key(:'x-queue-type')
+      end
+
+      it 'returns empty arguments hash' do
+        opts = instance.default_options
+        expect(opts[:arguments]).to eq({})
+      end
+    end
+
+    context 'when active (infra mode with scoping enabled)' do
+      before do
+        stub_settings(true)
+        stub_identity(resolved: true)
+        stub_mode(infra: true, agent: false)
+      end
+
+      it 'sets passive: false' do
+        expect(instance.default_options[:passive]).to be false
+      end
+
+      it 'includes x-queue-type argument' do
+        opts = instance.default_options
+        expect(opts[:arguments]).to have_key(:'x-queue-type')
+      end
+    end
+  end
+
+  describe '#ensure_dlx' do
+    let(:channel_double) do
+      dbl = instance_double('Bunny::Channel')
+      allow(dbl).to receive(:exchange_declare)
+      allow(dbl).to receive(:queue_declare)
+      allow(dbl).to receive(:queue_bind)
+      dbl
+    end
+
+    before { allow(instance).to receive(:channel).and_return(channel_double) }
+
+    context 'when credential scoping is disabled' do
+      before { stub_settings(false) }
+
+      it 'creates the DLX exchange and queue' do
+        merged_options = { arguments: { 'x-dead-letter-exchange': 'github.dlx' } }
+        instance.ensure_dlx(merged_options)
+        expect(channel_double).to have_received(:exchange_declare).with('github.dlx', 'fanout', anything)
+      end
+    end
+
+    context 'when credential scoping is enabled' do
+      before { stub_settings(true) }
+
+      it 'skips DLX creation during bootstrap phase' do
+        stub_identity(resolved: false)
+        stub_mode(infra: true, agent: false)
+        merged_options = { arguments: { 'x-dead-letter-exchange': 'github.dlx' } }
+        instance.ensure_dlx(merged_options)
+        expect(channel_double).not_to have_received(:exchange_declare)
+      end
+
+      it 'skips DLX creation for worker mode' do
+        stub_identity(resolved: true)
+        stub_mode(infra: false, agent: false)
+        merged_options = { arguments: { 'x-dead-letter-exchange': 'github.dlx' } }
+        instance.ensure_dlx(merged_options)
+        expect(channel_double).not_to have_received(:exchange_declare)
+      end
+
+      it 'creates DLX for infra mode after identity resolves' do
+        stub_identity(resolved: true)
+        stub_mode(infra: true, agent: false)
+        merged_options = { arguments: { 'x-dead-letter-exchange': 'github.dlx' } }
+        instance.ensure_dlx(merged_options)
+        expect(channel_double).to have_received(:exchange_declare).with('github.dlx', 'fanout', anything)
+      end
+
+      it 'creates DLX for agent mode after identity resolves' do
+        stub_identity(resolved: true)
+        stub_mode(infra: false, agent: true)
+        merged_options = { arguments: { 'x-dead-letter-exchange': 'github.dlx' } }
+        instance.ensure_dlx(merged_options)
+        expect(channel_double).to have_received(:exchange_declare).with('github.dlx', 'fanout', anything)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements Phase 5 Group 2 (Transport Passive Declares) from the credential scoping design doc (`docs/plans/2026-04-07-credential-scoping-design.md` §5).

- **`Exchange#passive?`** — mode-aware passive declare: `false` when `dynamic_rmq_creds` flag is off (default, preserves all current behavior); during bootstrap phase (identity not yet resolved) always `true`; `false` for infra/agent after identity swap; `true` for worker mode
- **`Queue#passive?`** — same logic with an additional `own_queue?` exception: workers can actively declare their own queues (prefix-matched) but passively assert all shared queues
- **`Queue#own_queue?`** — checks `Identity::Process.queue_prefix`; returns `false` when identity unresolved, prefix nil/empty, or queue name doesn't start with the process's prefix
- **`ensure_dlx` guard** — skips DLX creation when `credential_scoping_enabled? && (bootstrap_phase? || !topology_mode?)`; only infra/agent create shared DLX topology
- **`PreconditionFailed` guard** — worker and bootstrap modes raise on mismatch instead of deleting and recreating shared topology (exchange + queue)
- **Argument stripping** — passive declares return empty `arguments` hash (no `x-dead-letter-exchange`, no `x-queue-type`) to prevent `PreconditionFailed` on argument mismatch
- **All helpers use `defined?` guards** — `credential_scoping_enabled?`, `bootstrap_phase?`, `topology_mode?` all safely fall back to current behavior when legion-settings / Legion::Identity / Legion::Mode are not loaded

All behavior is gated behind `dynamic_rmq_creds: false` (default). Zero behavior change for any existing deployment until the flag is explicitly enabled.

## Test plan

- [x] 660 RSpec examples, 0 failures
- [x] `bundle exec rubocop -A` — 0 offenses
- [x] New specs cover all mode/phase combinations: scoping disabled, bootstrap phase, infra mode, agent mode, worker mode (shared queue), worker mode (own queue)
- [x] `ensure_dlx` specs verify DLX is created for infra/agent post-identity and skipped for bootstrap/worker
- [x] Argument stripping verified: passive `default_options` returns empty `arguments` hash