### PR TITLE
Fleet WS-00F: fix Messages::Task#exchange string handling

### DIFF
--- a/lib/legion/transport/messages/task.rb
+++ b/lib/legion/transport/messages/task.rb
@@ -6,7 +6,7 @@ module Legion
       class Task < Legion::Transport::Message
         def exchange
           if @options.key?(:exchange) && @options[:exchange].is_a?(String)
-            Legion::Transport::Exchanges.new(@options[:exchange])
+            Legion::Transport::Exchange.new(@options[:exchange])
           else
             Legion::Transport::Exchanges::Task.new
           end

--- a/lib/legion/transport/version.rb
+++ b/lib/legion/transport/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Transport
-    VERSION = '1.4.16'
+    VERSION = '1.4.17'
   end
 end

--- a/spec/legion/messages/task_spec.rb
+++ b/spec/legion/messages/task_spec.rb
@@ -51,6 +51,39 @@ RSpec.describe Legion::Transport::Messages::Task do
     end
   end
 
+  describe '#exchange' do
+    let(:instance) do
+      obj = described_class.allocate
+      obj.instance_variable_set(:@options, options)
+      obj
+    end
+
+    context 'when exchange option is a String' do
+      let(:options) { { exchange: 'lex', function: 'task' } }
+
+      it 'does not raise NoMethodError' do
+        allow(Legion::Transport::Exchange).to receive(:new).with('lex').and_return(double('exchange'))
+        expect { instance.exchange }.not_to raise_error
+      end
+
+      it 'instantiates the base Exchange class with the given string name' do
+        exchange_double = double('exchange')
+        expect(Legion::Transport::Exchange).to receive(:new).with('lex').and_return(exchange_double)
+        expect(instance.exchange).to eq exchange_double
+      end
+    end
+
+    context 'when exchange option is not set' do
+      let(:options) { { function: 'task' } }
+
+      it 'returns a Task exchange instance' do
+        task_exchange = double('task_exchange')
+        allow(Legion::Transport::Exchanges::Task).to receive(:new).and_return(task_exchange)
+        expect(instance.exchange).to eq task_exchange
+      end
+    end
+  end
+
   describe '#validate' do
     it 'raises TypeError when function is not a String' do
       instance = described_class.allocate


### PR DESCRIPTION
## Summary

- `Messages::Task#exchange` called `Exchanges.new(string)` — but `Exchanges` is a module; this raises `NoMethodError`
- Fix: use `Exchange.new(string)` (base class), matching the established pattern in `Messages::Dynamic#exchange`

## Test plan

- [x] Added `#exchange` specs to `spec/legion/messages/task_spec.rb`
- [x] Watched tests fail with `NoMethodError: undefined method 'new' for module Legion::Transport::Exchanges`
- [x] Applied one-line fix, tests pass
- [x] Full suite: 0 new failures (6 pre-existing spool/helper failures unrelated to this change)
- [x] Rubocop: 0 offenses