### PR TITLE
fleet(transport): add nack_or_dlq helper for WS-05 retry counting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.4.18] - 2026-04-13
+
+### Added
+- `Queue#nack_or_dlq(delivery_tag, retry_count:, threshold:)` — convenience helper: rejects with `requeue: true` when `retry_count < threshold`, dead-letters with `requeue: false` otherwise
+
 ## [1.4.16] - 2026-04-07
 
 ### Added

--- a/lib/legion/transport/queue.rb
+++ b/lib/legion/transport/queue.rb
@@ -117,6 +117,14 @@ module Legion
         channel.reject(delivery_tag, requeue)
       end
 
+      def nack_or_dlq(delivery_tag, retry_count: 0, threshold: 2)
+        if retry_count < threshold
+          reject(delivery_tag, requeue: true)
+        else
+          reject(delivery_tag, requeue: false)
+        end
+      end
+
       private
 
       def credential_scoping_enabled?

--- a/lib/legion/transport/version.rb
+++ b/lib/legion/transport/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Transport
-    VERSION = '1.4.17'
+    VERSION = '1.4.18'
   end
 end

--- a/spec/queue_retry_spec.rb
+++ b/spec/queue_retry_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Legion::Transport::Queue do
+  describe '#nack_or_dlq' do
+    let(:queue) { described_class.allocate }
+    let(:tag) { 'delivery-tag-1' }
+
+    before do
+      allow(queue).to receive(:reject)
+    end
+
+    it 'rejects with requeue: true when retry_count is below threshold' do
+      queue.nack_or_dlq(tag, retry_count: 0, threshold: 2)
+      expect(queue).to have_received(:reject).with(tag, requeue: true)
+    end
+
+    it 'rejects with requeue: true when retry_count is 1 below threshold' do
+      queue.nack_or_dlq(tag, retry_count: 1, threshold: 2)
+      expect(queue).to have_received(:reject).with(tag, requeue: true)
+    end
+
+    it 'dead-letters when retry_count equals threshold' do
+      queue.nack_or_dlq(tag, retry_count: 2, threshold: 2)
+      expect(queue).to have_received(:reject).with(tag, requeue: false)
+    end
+
+    it 'dead-letters when retry_count exceeds threshold' do
+      queue.nack_or_dlq(tag, retry_count: 5, threshold: 2)
+      expect(queue).to have_received(:reject).with(tag, requeue: false)
+    end
+
+    it 'dead-letters immediately when threshold is 0' do
+      queue.nack_or_dlq(tag, retry_count: 0, threshold: 0)
+      expect(queue).to have_received(:reject).with(tag, requeue: false)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `Queue#nack_or_dlq(delivery_tag, retry_count:, threshold:)` convenience helper
- When `retry_count < threshold`: rejects with `requeue: true` (RabbitMQ native requeue)
- When `retry_count >= threshold`: rejects with `requeue: false` → dead-letter exchange (DLX)

## Context

Part of **WS-05 Fleet Pipeline – Retry Counting**. The primary retry mechanism is in LegionIO's `Subscription` actor (companion PR), which uses the republish-and-ack pattern with `x-retry-count` header tracking. This helper provides a simpler requeue-based alternative for actors that don't need header counting.

## Test plan

- [ ] `bundle exec rspec spec/queue_retry_spec.rb` — 5 new examples, all boundary conditions
- [ ] `bundle exec rspec` — 668 total examples, 0 failures
- [ ] `bundle exec rubocop lib/legion/transport/queue.rb` — 0 offenses

## Merge order

Merge this PR **before** the LegionIO companion PR.