### PR TITLE
feat: add identity trust level to AMQP message headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.4.22] - 2026-04-24
+
+### Added
+- `x-legion-identity-trust` header on AMQP messages alongside existing `x-legion-identity-canonical-name`
+
 ## [1.4.21] - 2026-04-17
 
 ### Fixed

--- a/lib/legion/transport/message.rb
+++ b/lib/legion/transport/message.rb
@@ -220,6 +220,7 @@ module Legion
         id = Legion::Identity::Process.identity_hash
         {
           'x-legion-identity-canonical-name' => id[:canonical_name].to_s,
+          'x-legion-identity-trust'          => id[:trust].to_s,
           'x-legion-identity-id'             => id[:id].to_s,
           'x-legion-identity-kind'           => id[:kind].to_s,
           'x-legion-identity-mode'           => id[:mode].to_s,

--- a/lib/legion/transport/version.rb
+++ b/lib/legion/transport/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Transport
-    VERSION = '1.4.21'
+    VERSION = '1.4.22'
   end
 end


### PR DESCRIPTION
## Summary
Adds `x-legion-identity-trust` header to AMQP messages alongside the existing `x-legion-identity-canonical-name` header. Consumers can now distinguish verified vs cached vs unverified identity on incoming messages.

## Test plan
- [x] Rubocop: 0 offenses
- [ ] Verify header present on published messages