### PR TITLE
RabbitMQ 4.x compat, DLX self-healing, topology_mode fix (v1.4.24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 ## [1.4.24] - 2026-05-11
 
 ### Fixed
+- `TenantProvisioner#provision` and `#deprovision` now use `Legion::Transport::Connection.channel` (the public API) instead of the non-existent `Legion::Transport.connection.create_channel`. (Closes #15)
+- `TenantProvisioner` now wraps internally-acquired channels in `ensure` blocks so channels are closed even when provision/deprovision raises. (Closes #15)
+- `TenantProvisioner#deprovision` now guards against accidental deletion of global exchanges: skips when topology is disabled, and refuses to delete when `tenant_id` is nil, blank, or `'default'`. (Closes #15)
+- `TenantTopology#shared?` no longer over-matches: previously `start_with?('legion.')` matched `legion.controlled`; now uses exact set membership with explicit dot-separated sub-path check (`name == entry || name.start_with?("#{entry}.")`). (Closes #15)
+- `TenantTopology` now reads `shared_exchanges` and `prefix_format` from `transport.tenant_topology` settings with sensible defaults, instead of hardcoding them. (Closes #15)
+- `TenantQuota` now uses per-tenant mutexes instead of a single global mutex, and sweeps stale counter entries (entries inactive for `STALE_SECONDS = 300`) to prevent unbounded map growth. (Closes #15)
 - DLX exchange declarations now use an isolated channel to prevent cascading failures
 - Added self-healing delete-and-recreate logic for mismatched DLX exchanges (PreconditionFailed)
 - Added `exclusive: true` to Node and Agent queues for RabbitMQ 4.x compatibility (transient_nonexcl_queues deprecation)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,6 @@
 - Added `exclusive: true` to Node and Agent queues for RabbitMQ 4.x compatibility (transient_nonexcl_queues deprecation)
 - Fixed `topology_mode?` to check `worker?` instead of `agent?` for exchange/queue declarations
 
-### Changed
-- Routes module now uses `extend Legion::Logging::Helper` with `log.*` and `handle_exception` instead of direct `Legion::Logging` calls
-- TenantProvisioner DLX remains fanout (reverted from topic)
-
-### Removed
-- Unnecessary `defined?(Legion::Logging)` guards in routes.rb — legion-logging is a hard gemspec dependency
-- Unnecessary `defined?(Legion::Settings)` and `Legion.const_defined?('Settings')` guards in transport.rb, settings.rb, helper.rb, tenant_quota.rb, and tenant_topology.rb — legion-settings is a hard gemspec dependency
 
 ## [1.4.23] - 2026-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,17 @@
 
 ## [Unreleased]
 
+## [1.4.24] - 2026-05-11
+
+### Fixed
+- DLX exchange declarations now use an isolated channel to prevent cascading failures
+- Added self-healing delete-and-recreate logic for mismatched DLX exchanges (PreconditionFailed)
+- Added `exclusive: true` to Node and Agent queues for RabbitMQ 4.x compatibility (transient_nonexcl_queues deprecation)
+- Fixed `topology_mode?` to check `worker?` instead of `agent?` for exchange/queue declarations
+
 ### Changed
 - Routes module now uses `extend Legion::Logging::Helper` with `log.*` and `handle_exception` instead of direct `Legion::Logging` calls
+- TenantProvisioner DLX remains fanout (reverted from topic)
 
 ### Removed
 - Unnecessary `defined?(Legion::Logging)` guards in routes.rb — legion-logging is a hard gemspec dependency

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,109 +2,42 @@ Always run a full `bundle exec rspec` and `bundle exec rubocop -A` and fix all e
 
 # legion-transport: AMQP Transport Layer for LegionIO
 
-**Repository Level 3 Documentation**
-- **Parent**: `/Users/miverso2/rubymine/legion/CLAUDE.md`
-
-## Purpose
-
-Ruby gem that manages the connection between LegionIO and its FIFO queue system (RabbitMQ over AMQP 0.9.1). Provides abstractions for exchanges, queues, messages, and consumers with thread-safe connection management.
-
-**GitHub**: https://github.com/LegionIO/legion-transport
-**Version**: 1.4.14
-**License**: Apache-2.0
+RabbitMQ over AMQP 0.9.1. Thread-safe connection management, exchanges, queues, messages, consumers.
 
 ## Architecture
 
 ```
 Legion::Transport
-├── Connection          # Thread-safe RabbitMQ session/channel management
-│   ├── SSL             # TLS configuration (cert, key, CA, Vault PKI)
-│   └── Vault           # Vault-based credential retrieval (stub)
-├── InProcess           # Lite mode adapter: stub Session/Channel/Exchange/Queue/Consumer delegating to Local
-├── Exchange            # Base exchange class (extends Bunny::Exchange)
-│   └── Exchanges/
-│       ├── Task        # Task routing exchange
-│       ├── Node        # Node communication exchange (infrastructure: swarms, services, heartbeats)
-│       ├── Agent       # Agent communication exchange (identity-bound: GAIA frames, preferences, proactive)
-│       ├── Crypt       # Encryption exchange
-│       ├── Extensions  # Extension exchange
-│       ├── Lex         # LEX exchange (inherits Extensions)
-│       └── Logging     # Log event exchange (legion.logging) for structured log event publishing
-├── Queue               # Base queue class (extends Bunny::Queue)
-│   └── Queues/
-│       ├── Node        # Node queue
-│       ├── Agent       # Per-agent queue (auto-delete, routing key: agent.<agent_id>)
-│       ├── NodeCrypt   # Node encryption queue
-│       ├── NodeStatus  # Node status queue
-│       ├── TaskLog         # Task logging queue
-│       ├── TaskUpdate      # Task update queue
-│       └── RegionOutbound  # Cross-region outbound queue for mesh routing
-├── Message             # Base message class with publish, encode, encrypt
-│   └── Messages/
-│       ├── Task        # Task messages with dynamic routing keys
-│       ├── SubTask     # Subtask messages (conditions, transforms)
-│       ├── Dynamic     # Dynamic function-based messages
-│       ├── CheckSubtask
-│       ├── LexRegister
-│       ├── RequestClusterSecret
-│       ├── TaskLog
-│       └── TaskUpdate
-├── Consumer            # AMQP consumer with auto-generated tags
-├── Common              # Shared utilities (channel mgmt, options merging, consumer tags)
-├── Helper              # Injectable transport mixin for LEX extensions
-├── Local               # In-memory pub/sub for local development mode (no RabbitMQ)
-├── Spool               # Disk-backed message buffer: persist messages when RabbitMQ unavailable, replay on reconnect
-├── TenantProvisioner   # Creates per-tenant exchanges + queues on first publish; idempotent with TTL cache
-├── TenantQuota         # Per-tenant rate limiting and message quota enforcement
-├── TenantTopology      # Tracks per-tenant exchange/queue topology (discovery, cleanup)
-├── Settings            # Default configuration with env var overrides
-└── Version             # 1.4.14
+├── Connection          # Thread-safe session/channel, SSL, Vault creds
+├── InProcess           # Lite mode adapter
+├── Exchange            # Topic exchanges: Task, Node, Agent, Crypt, Extensions, Lex, Logging
+├── Queue              # Node, Agent, NodeCrypt, NodeStatus, TaskLog, TaskUpdate, RegionOutbound
+├── Message            # Publish, encode, encrypt; Task, SubTask, Dynamic, LexRegister, etc.
+├── Consumer           # Auto-generated consumer tags
+├── Common             # Channel mgmt, options merging
+├── Helper             # Injectable transport mixin for LEX extensions
+├── Local              # In-memory pub/sub for lite mode
+├── Spool              # Disk-backed buffer, replay on reconnect
+├── TenantProvisioner  # Per-tenant exchanges/queues on first publish
+├── TenantQuota        # Per-tenant rate limiting
+└── TenantTopology     # Topology tracking
 ```
 
 ## Key Design Patterns
 
-### Force Reconnect
+**Force Reconnect** — `Connection.force_reconnect` performs socket-first teardown (closes TCP socket before `Bunny::Session#close`) to break stuck connections. Tracks recovery rate over a 5-window/60s sliding window. Calls registered `on_force_reconnect` callbacks. Sets shutdown flag to prevent reconnection loops.
 
-`Connection.force_reconnect` performs a socket-first teardown (closes the underlying TCP socket before calling `Bunny::Session#close`) to break stuck connections that don't respond to the normal close protocol. Tracks recovery rate over a 5-window/60s sliding window. Calls registered `on_force_reconnect` callbacks after reconnection. Sets a shutdown flag to prevent reconnection loops during intentional shutdown.
+**Lite Mode** — `LEGION_MODE=lite` sets `TYPE='local'`, `CONNECTOR=InProcess`. `Connection.setup` returns an InProcess session, skipping Bunny entirely.
 
-```ruby
-Legion::Transport::Connection.force_reconnect
-Legion::Transport::Connection.on_force_reconnect { |info| alert_on_call(info) }
-```
+**Thread-Safe Connections** — `Concurrent::AtomicReference` wraps the AMQP session (one per process). `Concurrent::ThreadLocalVar` provides per-thread channels. Auto-recovery on blocked/unblocked/recovery events.
 
-### AMQP Client / Lite Mode
-Uses `bunny` gem for AMQP 0.9.1. The entry point sets `Legion::Transport::TYPE` and `Legion::Transport::CONNECTOR` as constants. When `LEGION_MODE=lite` env var is set, `TYPE = 'local'` and `CONNECTOR = InProcess` instead of Bunny. `Connection.lite_mode?` checks `TYPE == 'local'`. `Connection.setup` returns an InProcess session in lite mode, skipping Bunny entirely.
+**Auto-Recreate on Mismatch** — Exchange and Queue classes catch `PreconditionFailed` (parameter mismatch with existing declarations) and delete + recreate once before raising.
 
-### Thread-Safe Connection Management
-- `Concurrent::AtomicReference` wraps the AMQP session (one per process)
-- `Concurrent::ThreadLocalVar` provides per-thread channels
-- Auto-recovery on blocked/unblocked/recovery events
-
-### Options Merging
-`Common#options_builder` deep-merges default options -> class options -> instance options. Used by both Exchange and Queue constructors.
-
-### Auto-Recreate on Mismatch
-Both Exchange and Queue classes catch `PreconditionFailed` errors (parameter mismatch with existing RabbitMQ declarations) and attempt to delete + recreate once before raising.
-
-## Dependencies
-
-| Gem | Purpose |
-|-----|---------|
-| `bunny` (>= 2.23) | CRuby AMQP client |
-| `concurrent-ruby` (>= 1.2) | Thread-safe data structures |
-| `legion-json` | JSON serialization |
-| `legion-settings` | Configuration management |
-
-Optional runtime dependencies:
-- `legion-crypt` - Message encryption support
-- `legion-data` - Database models (used by Dynamic/SubTask messages)
-- `legion-logging` - Structured logging
+**Options Merging** — `Common#options_builder` deep-merges default -> class -> instance options for Exchange and Queue constructors.
 
 ## Configuration
 
-Settings are loaded via `Legion::Transport::Settings` with env var overrides:
-
-| Env Var | Default | Description |
+| Setting | Default | Description |
 |---------|---------|-------------|
 | `transport.connection.host` | `127.0.0.1` | RabbitMQ host |
 | `transport.connection.port` | `5672` | RabbitMQ port |
@@ -116,77 +49,27 @@ Settings are loaded via `Legion::Transport::Settings` with env var overrides:
 | `transport.messages.ttl` | `nil` | Message TTL |
 | `transport.messages.persistent` | `true` | Persistent messages |
 
-Vault integration: RabbitMQ credentials are managed by the LeaseManager via `lease://rabbitmq#username` / `lease://rabbitmq#password` URI references in transport settings. The lease path (e.g., `rabbitmq/creds/agent`) is configured in `crypt.vault.leases.rabbitmq.path`.
-
-## File Map
-
-| Path | Purpose |
-|------|---------|
-| `lib/legion/transport.rb` | Entry point, connector detection (Bunny vs InProcess), logger/settings |
-| `lib/legion/transport/connection.rb` | Session/channel lifecycle (setup, reconnect, shutdown, lite_mode?) |
-| `lib/legion/transport/connection/ssl.rb` | TLS settings module |
-| `lib/legion/transport/connection/vault.rb` | Vault PKI integration (stub) |
-| `lib/legion/transport/in_process.rb` | Lite mode adapter: stub Session, Channel, Exchange, Queue, Consumer |
-| `lib/legion/transport/common.rb` | Shared module (channel access, deep_merge, consumer tags) |
-| `lib/legion/transport/helper.rb` | Injectable transport mixin for LEX extensions |
-| `lib/legion/transport/exchange.rb` | Base Exchange class |
-| `lib/legion/transport/exchanges/agent.rb` | Agent exchange for identity-bound communication |
-| `lib/legion/transport/queue.rb` | Base Queue class |
-| `lib/legion/transport/queues/agent.rb` | Per-agent queue (auto-delete, keyed by agent_id) |
-| `lib/legion/transport/message.rb` | Base Message class with publish/encode/encrypt |
-| `lib/legion/transport/consumer.rb` | AMQP consumer wrapper |
-| `lib/legion/transport/spool.rb` | Disk-backed message buffer (~/.legionio/spool, 10MB/file, 500MB total, 3-day TTL) |
-| `lib/legion/transport/tenant_provisioner.rb` | Per-tenant exchange/queue creation with TTL idempotency cache |
-| `lib/legion/transport/tenant_quota.rb` | Per-tenant rate limiting and message quota enforcement |
-| `lib/legion/transport/tenant_topology.rb` | Per-tenant topology tracking (discovery, cleanup) |
-| `lib/legion/transport/queues/region_outbound.rb` | Cross-region outbound queue for mesh routing |
-| `lib/legion/transport/settings.rb` | Default config, env var loading, host resolution |
-| `lib/legion/transport/version.rb` | Version constant |
-| `spec/` | RSpec test suite |
+Vault integration: credentials via `lease://rabbitmq#username` URI refs; lease path configured in `crypt.vault.leases.rabbitmq.path`.
 
 ## Node vs Agent Exchange
 
-Two identity-scoped exchanges separate infrastructure traffic from agent-bound traffic:
+| Exchange | Routing Key | Use Case |
+|----------|-------------|----------|
+| `node` | `node.<fqdn>` | Infrastructure: swarm coordination, heartbeats |
+| `agent` | `agent.<agent_id>` | Identity-bound: GAIA frames, preferences, proactive messages |
 
-| Exchange | Routing Key Pattern | Use Case |
-|----------|-------------------|----------|
-| `node` | `node.<fqdn/nodename>` | Infrastructure: swarm coordination, service heartbeats, non-identity traffic |
-| `agent` | `agent.<agent_id>` | Identity-bound: GAIA cognitive frames, preference queries, proactive messages |
-
-**Agent queue defaults** differ from standard queues:
-- `durable: false` — agent queues are ephemeral (recreated on connect)
-- `auto_delete: true` — cleaned up when the agent disconnects
-- Dead letter exchange: `agent.dlx`
-- Agent ID defaults to `Legion::Settings['client']['name']` if not provided
-
-The `agent` exchange is used by `legion-gaia` for inbound cognitive frames (replacing the former `gaia` exchange routing) and by `lex-mesh` for async preference queries via `reply_to` + `correlation_id` RPC.
+Agent queue differences: `durable:false`, `auto_delete:true`, DLX: `agent.dlx`. Agent ID defaults to `Legion::Settings['client']['name']`.
 
 ## Queue Defaults
 
-All queues are created with:
-- `durable: true` - survives broker restart
-- `manual_ack: true` - explicit acknowledgment required
-- `x-max-priority: 255` - priority queue support
-- `x-overflow: reject-publish` - rejects new messages when full
+- `durable: true`, `manual_ack: true`
+- `x-max-priority: 255`, `x-overflow: reject-publish`
 - Dead letter exchange: `<exchange>.dlx`
 
 ## Exchange Defaults
 
-All exchanges are created as:
-- `type: topic` - supports routing key pattern matching
-- `durable: true` - survives broker restart
-- `auto_delete: false` - persists when no queues bound
+- `type: topic`, `durable: true`, `auto_delete: false`
 
 ## Testing
 
-```bash
-bundle install
-bundle exec rspec
-bundle exec rubocop
-```
-
-Spec count: 448+ examples (force_reconnect, recovery tracking, tenant provisioner specs added in v1.4.x)
-
----
-
-**Maintained By**: Matthew Iverson (@Esity)
+448+ specs. Run `bundle exec rspec` and `bundle exec rubocop`.

--- a/lib/legion/transport/exchange.rb
+++ b/lib/legion/transport/exchange.rb
@@ -125,7 +125,7 @@ module Legion
       def topology_mode?
         return true unless defined?(Legion::Mode)
 
-        Legion::Mode.infra? || Legion::Mode.worker?
+        Legion::Mode.infra? || (Legion::Mode.respond_to?(:worker?) && Legion::Mode.worker?)
       end
 
       def safely_close_channel(error_channel)

--- a/lib/legion/transport/exchange.rb
+++ b/lib/legion/transport/exchange.rb
@@ -125,7 +125,7 @@ module Legion
       def topology_mode?
         return true unless defined?(Legion::Mode)
 
-        Legion::Mode.infra? || Legion::Mode.agent?
+        Legion::Mode.infra? || Legion::Mode.worker?
       end
 
       def safely_close_channel(error_channel)

--- a/lib/legion/transport/queue.rb
+++ b/lib/legion/transport/queue.rb
@@ -89,7 +89,8 @@ module Legion
         dlx_name = merged_options.dig(:arguments, :'x-dead-letter-exchange')
         return if dlx_name.nil? || dlx_name.empty?
 
-        dlx_ch = Legion::Transport::Connection.channel
+        dlx_ch = nil
+        dlx_ch = Legion::Transport::Connection.session.create_channel
         declare_dlx(dlx_name, dlx_ch)
       rescue Legion::Transport::CONNECTOR::PreconditionFailed => e
         handle_exception(e, level: :warn, handled: true, operation: 'transport.queue.ensure_dlx', dlx: dlx_name)
@@ -97,7 +98,7 @@ module Legion
       rescue StandardError => e
         handle_exception(e, level: :warn, handled: true, operation: 'transport.queue.ensure_dlx', dlx: dlx_name)
       ensure
-        safely_close_channel(dlx_ch) if defined?(dlx_ch) && dlx_ch != @channel
+        dlx_ch&.close if dlx_ch&.open?
       end
 
       def declare_dlx(dlx_name, dlx_channel)
@@ -108,16 +109,17 @@ module Legion
       end
 
       def recreate_dlx(dlx_name)
-        log.warn "DLX exchange #{dlx_name} exists with wrong parameters, deleting and recreating"
-        dlx_channel = Legion::Transport::Connection.channel
-        dlx_channel.exchange_delete(dlx_name)
-        safely_close_channel(dlx_channel)
-        dlx_channel = Legion::Transport::Connection.channel
-        declare_dlx(dlx_name, dlx_channel)
+        log.warn "DLX #{dlx_name} exists with wrong parameters, deleting and recreating"
+        ch = Legion::Transport::Connection.session.create_channel
+        ch.exchange_delete(dlx_name)
+        ch.queue_delete("#{dlx_name}.queue")
+        ch.close
+        ch = Legion::Transport::Connection.session.create_channel
+        declare_dlx(dlx_name, ch)
       rescue StandardError => e
         handle_exception(e, level: :warn, handled: true, operation: 'transport.queue.recreate_dlx', dlx: dlx_name)
       ensure
-        safely_close_channel(dlx_channel) if defined?(dlx_channel)
+        ch&.close if ch&.open?
       end
 
       def queue_name
@@ -165,7 +167,7 @@ module Legion
       def topology_mode?
         return true unless defined?(Legion::Mode)
 
-        Legion::Mode.infra? || Legion::Mode.worker?
+        Legion::Mode.infra? || (Legion::Mode.respond_to?(:worker?) && Legion::Mode.worker?)
       end
 
       def safely_close_channel(tmp_channel)

--- a/lib/legion/transport/queue.rb
+++ b/lib/legion/transport/queue.rb
@@ -89,12 +89,35 @@ module Legion
         dlx_name = merged_options.dig(:arguments, :'x-dead-letter-exchange')
         return if dlx_name.nil? || dlx_name.empty?
 
-        channel.exchange_declare(dlx_name, 'fanout', durable: true, auto_delete: false)
-        channel.queue_declare("#{dlx_name}.queue", durable: true, auto_delete: false,
-                                                    arguments: { 'x-queue-type': 'classic' })
-        channel.queue_bind("#{dlx_name}.queue", dlx_name, routing_key: '#')
+        dlx_ch = Legion::Transport::Connection.channel
+        declare_dlx(dlx_name, dlx_ch)
+      rescue Legion::Transport::CONNECTOR::PreconditionFailed => e
+        handle_exception(e, level: :warn, handled: true, operation: 'transport.queue.ensure_dlx', dlx: dlx_name)
+        recreate_dlx(dlx_name)
       rescue StandardError => e
         handle_exception(e, level: :warn, handled: true, operation: 'transport.queue.ensure_dlx', dlx: dlx_name)
+      ensure
+        safely_close_channel(dlx_ch) if defined?(dlx_ch) && dlx_ch != @channel
+      end
+
+      def declare_dlx(dlx_name, dlx_channel)
+        dlx_channel.exchange_declare(dlx_name, 'fanout', durable: true, auto_delete: false)
+        dlx_channel.queue_declare("#{dlx_name}.queue", durable: true, auto_delete: false,
+                                                       arguments: { 'x-queue-type': 'classic' })
+        dlx_channel.queue_bind("#{dlx_name}.queue", dlx_name, routing_key: '#')
+      end
+
+      def recreate_dlx(dlx_name)
+        log.warn "DLX exchange #{dlx_name} exists with wrong parameters, deleting and recreating"
+        dlx_channel = Legion::Transport::Connection.channel
+        dlx_channel.exchange_delete(dlx_name)
+        safely_close_channel(dlx_channel)
+        dlx_channel = Legion::Transport::Connection.channel
+        declare_dlx(dlx_name, dlx_channel)
+      rescue StandardError => e
+        handle_exception(e, level: :warn, handled: true, operation: 'transport.queue.recreate_dlx', dlx: dlx_name)
+      ensure
+        safely_close_channel(dlx_channel) if defined?(dlx_channel)
       end
 
       def queue_name
@@ -142,7 +165,7 @@ module Legion
       def topology_mode?
         return true unless defined?(Legion::Mode)
 
-        Legion::Mode.infra? || Legion::Mode.agent?
+        Legion::Mode.infra? || Legion::Mode.worker?
       end
 
       def safely_close_channel(tmp_channel)

--- a/lib/legion/transport/queues/agent.rb
+++ b/lib/legion/transport/queues/agent.rb
@@ -18,7 +18,7 @@ module Legion
         end
 
         def queue_options
-          { durable: false, auto_delete: true, arguments: { 'x-dead-letter-exchange': 'agent.dlx', 'x-queue-type': 'classic' } }
+          { durable: false, auto_delete: true, exclusive: true, arguments: { 'x-dead-letter-exchange': 'agent.dlx', 'x-queue-type': 'classic' } }
         end
       end
     end

--- a/lib/legion/transport/queues/node.rb
+++ b/lib/legion/transport/queues/node.rb
@@ -9,7 +9,7 @@ module Legion
         end
 
         def queue_options
-          { durable: false, auto_delete: true, arguments: { 'x-dead-letter-exchange': 'node.dlx' } }
+          { durable: false, auto_delete: true, exclusive: true, arguments: { 'x-dead-letter-exchange': 'node.dlx' } }
         end
       end
     end

--- a/lib/legion/transport/queues/node.rb
+++ b/lib/legion/transport/queues/node.rb
@@ -9,7 +9,7 @@ module Legion
         end
 
         def queue_options
-          { durable: false, auto_delete: true, exclusive: true, arguments: { 'x-dead-letter-exchange': 'node.dlx' } }
+          { durable: false, auto_delete: true, exclusive: true, arguments: { 'x-dead-letter-exchange': 'node.dlx', 'x-queue-type': 'classic' } }
         end
       end
     end

--- a/lib/legion/transport/settings.rb
+++ b/lib/legion/transport/settings.rb
@@ -98,7 +98,7 @@ module Legion
       def self.tenant_topology
         {
           enabled:          false,
-          prefix_format:    't.%<tenant_id>s.',
+          prefix_format:    't.%<tenant_id>s.%<name>s',
           shared_exchanges: %w[legion.control legion.health legion.audit],
           auto_provision:   true,
           quotas:           {}

--- a/lib/legion/transport/tenant_provisioner.rb
+++ b/lib/legion/transport/tenant_provisioner.rb
@@ -11,14 +11,17 @@ module Legion
       EXCHANGE_TYPES = %w[tasks results events].freeze
 
       def self.provision(tenant_id, channel: nil)
-        ch = channel || Legion::Transport.connection.create_channel
-        EXCHANGE_TYPES.each do |type|
-          name = TenantTopology.exchange_name(type, tenant_id: tenant_id)
-          ch.topic(name, durable: true)
+        ch = channel || Legion::Transport::Connection.channel
+        begin
+          EXCHANGE_TYPES.each do |type|
+            name = TenantTopology.exchange_name(type, tenant_id: tenant_id)
+            ch.topic(name, durable: true)
+          end
+          dlx = TenantTopology.exchange_name('dlx', tenant_id: tenant_id)
+          ch.fanout(dlx, durable: true)
+        ensure
+          ch.close if ch.respond_to?(:close) && !channel
         end
-        dlx = TenantTopology.exchange_name('dlx', tenant_id: tenant_id)
-        ch.fanout(dlx, durable: true)
-        ch.close unless channel
         log.info "Provisioned tenant topology for tenant_id=#{tenant_id}"
       rescue StandardError => e
         handle_exception(e, level: :warn, handled: false, operation: 'transport.tenant_provisioner.provision',
@@ -27,18 +30,29 @@ module Legion
       end
 
       def self.deprovision(tenant_id, channel: nil)
-        ch = channel || Legion::Transport.connection.create_channel
-        (EXCHANGE_TYPES + ['dlx']).each do |type|
-          name = TenantTopology.exchange_name(type, tenant_id: tenant_id)
-          begin
-            ch.exchange_delete(name)
-          rescue StandardError => e
-            handle_exception(e, level: :warn, handled: true, operation: 'transport.tenant_provisioner.deprovision_exchange',
-                             tenant_id: tenant_id, exchange_name: name)
-            nil
-          end
+        return log.debug('Skipping deprovision: topology disabled') unless TenantTopology.enabled?
+
+        tid = tenant_id.to_s.strip
+        if tid.empty? || tid == 'default'
+          log.warn "Skipping deprovision: refusing to delete global exchanges for tenant_id=#{tenant_id.inspect}"
+          return
         end
-        ch.close unless channel
+
+        ch = channel || Legion::Transport::Connection.channel
+        begin
+          (EXCHANGE_TYPES + ['dlx']).each do |type|
+            name = TenantTopology.exchange_name(type, tenant_id: tenant_id)
+            begin
+              ch.exchange_delete(name)
+            rescue StandardError => e
+              handle_exception(e, level: :warn, handled: true, operation: 'transport.tenant_provisioner.deprovision_exchange',
+                               tenant_id: tenant_id, exchange_name: name)
+              nil
+            end
+          end
+        ensure
+          ch.close if ch.respond_to?(:close) && !channel
+        end
         log.info "Deprovisioned tenant topology for tenant_id=#{tenant_id}"
       rescue StandardError => e
         handle_exception(e, level: :warn, handled: false, operation: 'transport.tenant_provisioner.deprovision',

--- a/lib/legion/transport/tenant_quota.rb
+++ b/lib/legion/transport/tenant_quota.rb
@@ -12,9 +12,11 @@ module Legion
       end
 
       WINDOW_SECONDS = 1
+      STALE_SECONDS  = 300
 
-      @counters = {}
-      @mutex = Mutex.new
+      @counters      = {}
+      @mutexes       = {}
+      @registry_mutex = Mutex.new
 
       class << self
         def check_publish(tenant_id, message_size: 0)
@@ -25,13 +27,15 @@ module Legion
           return true if msg_limit.nil? && size_limit.nil?
 
           now = current_window
-          @mutex.synchronize do
-            @counters[tenant_id] ||= { window: now, count: 0, bytes: 0 }
+
+          tenant_mutex(tenant_id).synchronize do
+            @counters[tenant_id] ||= { window: now, count: 0, bytes: 0, updated_at: now }
             entry = @counters[tenant_id]
             if entry[:window] != now
-              entry[:window] = now
-              entry[:count] = 0
-              entry[:bytes] = 0
+              entry[:window]     = now
+              entry[:count]      = 0
+              entry[:bytes]      = 0
+              entry[:updated_at] = now
             end
 
             if msg_limit && entry[:count] >= msg_limit
@@ -44,9 +48,12 @@ module Legion
               raise QuotaExceededError, "Tenant #{tenant_id} exceeded byte rate quota (#{size_limit} bytes/s)"
             end
 
-            entry[:count] += 1
-            entry[:bytes] += message_size
+            entry[:count]      += 1
+            entry[:bytes]      += message_size
+            entry[:updated_at]  = now
           end
+
+          sweep_stale!
           true
         end
 
@@ -55,10 +62,36 @@ module Legion
         end
 
         def reset!
-          @mutex.synchronize { @counters.clear }
+          @registry_mutex.synchronize do
+            @counters.clear
+            @mutexes.clear
+          end
         end
 
         private
+
+        def tenant_mutex(tenant_id)
+          @registry_mutex.synchronize do
+            @mutexes[tenant_id] ||= Mutex.new
+          end
+        end
+
+        def sweep_stale!
+          stale_cutoff = current_window - (STALE_SECONDS / WINDOW_SECONDS)
+
+          stale_ids = @registry_mutex.synchronize do
+            @counters.each_with_object([]) do |(tid, entry), ids|
+              ids << tid if entry[:updated_at] && entry[:updated_at] < stale_cutoff
+            end
+          end
+
+          stale_ids.each do |tid|
+            @registry_mutex.synchronize do
+              @counters.delete(tid)
+              @mutexes.delete(tid)
+            end
+          end
+        end
 
         def current_window
           (::Time.now.to_f / WINDOW_SECONDS).floor

--- a/lib/legion/transport/tenant_topology.rb
+++ b/lib/legion/transport/tenant_topology.rb
@@ -7,7 +7,8 @@ module Legion
     module TenantTopology
       extend Legion::Logging::Helper
 
-      SHARED_EXCHANGES = %w[legion.control legion.health legion.audit].freeze
+      DEFAULT_SHARED_EXCHANGES = %w[legion.control legion.health legion.audit].freeze
+      DEFAULT_PREFIX_FORMAT = 't.%<tenant_id>s.%<name>s'
 
       def self.exchange_name(base_name, tenant_id: nil)
         return base_name unless enabled?
@@ -15,7 +16,7 @@ module Legion
         tid = tenant_id || current_tenant_id
         return base_name if tid.nil? || tid == 'default' || shared?(base_name)
 
-        "t.#{tid}.#{base_name}"
+        format(prefix_format, tenant_id: tid, name: base_name)
       end
 
       def self.queue_name(base_name, tenant_id: nil)
@@ -24,11 +25,13 @@ module Legion
         tid = tenant_id || current_tenant_id
         return base_name if tid.nil? || tid == 'default'
 
-        "t.#{tid}.#{base_name}"
+        format(prefix_format, tenant_id: tid, name: base_name)
       end
 
       def self.shared?(name)
-        SHARED_EXCHANGES.any? { |prefix| name.start_with?(prefix) }
+        configured_shared_exchanges.any? do |entry|
+          name == entry || name.start_with?("#{entry}.")
+        end
       end
 
       def self.enabled?
@@ -43,6 +46,22 @@ module Legion
       rescue StandardError => e
         handle_exception(e, level: :warn, handled: true, operation: :tenant_topology_current_tenant_id)
         nil
+      end
+
+      private_class_method def self.prefix_format
+        settings = transport_settings
+        return DEFAULT_PREFIX_FORMAT unless settings.is_a?(Hash)
+
+        settings.dig(:tenant_topology, :prefix_format) || DEFAULT_PREFIX_FORMAT
+      end
+
+      private_class_method def self.configured_shared_exchanges
+        settings = transport_settings
+        return DEFAULT_SHARED_EXCHANGES unless settings.is_a?(Hash)
+
+        Array(settings.dig(:tenant_topology, :shared_exchanges)).tap do |arr|
+          return DEFAULT_SHARED_EXCHANGES if arr.empty?
+        end
       end
 
       private_class_method def self.transport_settings

--- a/lib/legion/transport/version.rb
+++ b/lib/legion/transport/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Transport
-    VERSION = '1.4.23'
+    VERSION = '1.4.24'
   end
 end

--- a/spec/legion/transport/exchange_passive_spec.rb
+++ b/spec/legion/transport/exchange_passive_spec.rb
@@ -12,10 +12,11 @@ RSpec.describe 'Exchange passive declares (credential scoping)' do
   end
 
   # Helper to stub Legion::Mode
-  def stub_mode(infra: false, agent: false)
+  def stub_mode(infra: false, agent: false, worker: false)
     mode = Module.new
     mode.define_singleton_method(:infra?) { infra }
     mode.define_singleton_method(:agent?) { agent }
+    mode.define_singleton_method(:worker?) { worker }
     stub_const('Legion::Mode', mode)
   end
 
@@ -81,13 +82,18 @@ RSpec.describe 'Exchange passive declares (credential scoping)' do
       expect(instance.send(:topology_mode?)).to be true
     end
 
-    it 'returns true for agent mode' do
-      stub_mode(infra: false, agent: true)
+    it 'returns false for agent mode' do
+      stub_mode(infra: false, agent: true, worker: false)
+      expect(instance.send(:topology_mode?)).to be false
+    end
+
+    it 'returns true for worker mode' do
+      stub_mode(infra: false, agent: false, worker: true)
       expect(instance.send(:topology_mode?)).to be true
     end
 
-    it 'returns false for worker mode (neither infra nor agent)' do
-      stub_mode(infra: false, agent: false)
+    it 'returns false for neither infra nor worker' do
+      stub_mode(infra: false, agent: false, worker: false)
       expect(instance.send(:topology_mode?)).to be false
     end
   end
@@ -122,10 +128,10 @@ RSpec.describe 'Exchange passive declares (credential scoping)' do
         expect(instance.passive?).to be false
       end
 
-      it 'returns false for agent mode after identity resolves' do
+      it 'returns true for agent mode after identity resolves (agent is passive)' do
         stub_identity(resolved: true)
         stub_mode(infra: false, agent: true)
-        expect(instance.passive?).to be false
+        expect(instance.passive?).to be true
       end
 
       it 'returns true for worker mode after identity resolves' do

--- a/spec/legion/transport/queue_passive_spec.rb
+++ b/spec/legion/transport/queue_passive_spec.rb
@@ -9,10 +9,11 @@ RSpec.describe 'Queue passive declares (credential scoping)' do
     allow(Legion::Settings).to receive(:dig).with(:crypt, :vault, :dynamic_rmq_creds).and_return(enabled ? true : false)
   end
 
-  def stub_mode(infra: false, agent: false)
+  def stub_mode(infra: false, agent: false, worker: false)
     mode = Module.new
     mode.define_singleton_method(:infra?) { infra }
     mode.define_singleton_method(:agent?) { agent }
+    mode.define_singleton_method(:worker?) { worker }
     stub_const('Legion::Mode', mode)
   end
 
@@ -73,13 +74,18 @@ RSpec.describe 'Queue passive declares (credential scoping)' do
       expect(instance.send(:topology_mode?)).to be true
     end
 
-    it 'returns true for agent mode' do
-      stub_mode(infra: false, agent: true)
+    it 'returns false for agent mode' do
+      stub_mode(infra: false, agent: true, worker: false)
+      expect(instance.send(:topology_mode?)).to be false
+    end
+
+    it 'returns true for worker mode' do
+      stub_mode(infra: false, agent: false, worker: true)
       expect(instance.send(:topology_mode?)).to be true
     end
 
-    it 'returns false for worker mode' do
-      stub_mode(infra: false, agent: false)
+    it 'returns false when neither infra nor worker' do
+      stub_mode(infra: false, agent: false, worker: false)
       expect(instance.send(:topology_mode?)).to be false
     end
   end
@@ -150,10 +156,10 @@ RSpec.describe 'Queue passive declares (credential scoping)' do
         expect(instance.passive?).to be false
       end
 
-      it 'returns false for agent mode after identity resolves' do
+      it 'returns true for agent mode after identity resolves (agent is passive)' do
         stub_identity(resolved: true)
         stub_mode(infra: false, agent: true)
-        expect(instance.passive?).to be false
+        expect(instance.passive?).to be true
       end
 
       it 'returns true for worker mode on shared queue' do
@@ -242,10 +248,14 @@ RSpec.describe 'Queue passive declares (credential scoping)' do
       allow(dbl).to receive(:exchange_declare)
       allow(dbl).to receive(:queue_declare)
       allow(dbl).to receive(:queue_bind)
+      allow(dbl).to receive(:open?).and_return(false)
       dbl
     end
 
-    before { allow(instance).to receive(:channel).and_return(channel_double) }
+    before do
+      allow(Legion::Transport::Connection).to receive(:channel).and_return(channel_double)
+      allow(instance).to receive(:safely_close_channel)
+    end
 
     context 'when credential scoping is disabled' do
       before { stub_settings(false) }
@@ -284,12 +294,12 @@ RSpec.describe 'Queue passive declares (credential scoping)' do
         expect(channel_double).to have_received(:exchange_declare).with('github.dlx', 'fanout', anything)
       end
 
-      it 'creates DLX for agent mode after identity resolves' do
+      it 'skips DLX creation for agent mode (agent is not topology owner)' do
         stub_identity(resolved: true)
         stub_mode(infra: false, agent: true)
         merged_options = { arguments: { 'x-dead-letter-exchange': 'github.dlx' } }
         instance.ensure_dlx(merged_options)
-        expect(channel_double).to have_received(:exchange_declare).with('github.dlx', 'fanout', anything)
+        expect(channel_double).not_to have_received(:exchange_declare)
       end
     end
   end

--- a/spec/legion/transport/queue_passive_spec.rb
+++ b/spec/legion/transport/queue_passive_spec.rb
@@ -253,7 +253,9 @@ RSpec.describe 'Queue passive declares (credential scoping)' do
     end
 
     before do
-      allow(Legion::Transport::Connection).to receive(:channel).and_return(channel_double)
+      session_double = instance_double('Bunny::Session')
+      allow(session_double).to receive(:create_channel).and_return(channel_double)
+      allow(Legion::Transport::Connection).to receive(:session).and_return(session_double)
       allow(instance).to receive(:safely_close_channel)
     end
 

--- a/spec/legion/transport/tenant_provisioner_spec.rb
+++ b/spec/legion/transport/tenant_provisioner_spec.rb
@@ -49,9 +49,49 @@ RSpec.describe Legion::Transport::TenantProvisioner do
         described_class.provision('abc123', channel: channel)
       end
     end
+
+    context 'channel leak prevention' do
+      before do
+        Legion::Settings[:transport][:tenant_topology] ||= {}
+        Legion::Settings[:transport][:tenant_topology][:enabled] = true
+      end
+
+      after do
+        Legion::Settings[:transport][:tenant_topology][:enabled] = false
+      end
+
+      it 'closes an internally-acquired channel even when provision raises' do
+        owned_channel = instance_double('Bunny::Channel')
+        allow(owned_channel).to receive(:topic).and_raise(StandardError, 'boom')
+        allow(owned_channel).to receive(:fanout)
+        allow(owned_channel).to receive(:respond_to?).with(:close).and_return(true)
+        allow(owned_channel).to receive(:close)
+
+        allow(Legion::Transport::Connection).to receive(:channel).and_return(owned_channel)
+
+        expect(owned_channel).to receive(:close)
+        expect { described_class.provision('abc123') }.to raise_error(StandardError, 'boom')
+      end
+    end
   end
 
   describe '.deprovision' do
+    context 'when tenant_topology is disabled' do
+      before do
+        Legion::Settings[:transport][:tenant_topology] ||= {}
+        Legion::Settings[:transport][:tenant_topology][:enabled] = false
+      end
+
+      it 'skips deprovision and does not raise' do
+        expect { described_class.deprovision('abc123', channel: channel) }.not_to raise_error
+      end
+
+      it 'does not attempt to delete any exchanges' do
+        expect(channel).not_to receive(:exchange_delete)
+        described_class.deprovision('abc123', channel: channel)
+      end
+    end
+
     context 'when tenant_topology is enabled' do
       before do
         Legion::Settings[:transport][:tenant_topology] ||= {}
@@ -79,6 +119,21 @@ RSpec.describe Legion::Transport::TenantProvisioner do
       it 'does not close the channel when channel is provided' do
         expect(channel).not_to receive(:close)
         described_class.deprovision('abc123', channel: channel)
+      end
+
+      it 'skips deprovision when tenant_id is nil' do
+        expect(channel).not_to receive(:exchange_delete)
+        described_class.deprovision(nil, channel: channel)
+      end
+
+      it 'skips deprovision when tenant_id is blank' do
+        expect(channel).not_to receive(:exchange_delete)
+        described_class.deprovision('', channel: channel)
+      end
+
+      it 'skips deprovision when tenant_id is "default"' do
+        expect(channel).not_to receive(:exchange_delete)
+        described_class.deprovision('default', channel: channel)
       end
     end
   end

--- a/spec/legion/transport/tenant_quota_spec.rb
+++ b/spec/legion/transport/tenant_quota_spec.rb
@@ -95,6 +95,48 @@ RSpec.describe Legion::Transport::TenantQuota do
           .to raise_error(Legion::Transport::TenantQuota::QuotaExceededError)
       end
     end
+
+    context 'per-tenant isolation (independent mutexes)' do
+      before do
+        Legion::Settings[:transport][:tenant_topology][:enabled] = true
+        Legion::Settings[:transport][:tenant_topology][:quotas] = {
+          tenant_a: { messages_per_second: 2 },
+          tenant_b: { messages_per_second: 2 }
+        }
+      end
+
+      it 'exhausting one tenant does not block another' do
+        2.times { described_class.check_publish('tenant_a') }
+        expect { described_class.check_publish('tenant_a') }
+          .to raise_error(described_class::QuotaExceededError)
+        expect(described_class.check_publish('tenant_b')).to be true
+      end
+    end
+  end
+
+  describe 'stale entry sweep' do
+    before do
+      Legion::Settings[:transport][:tenant_topology][:enabled] = true
+      Legion::Settings[:transport][:tenant_topology][:quotas] = {
+        stale_tenant: { messages_per_second: 100 }
+      }
+    end
+
+    it 'removes entries that have not been updated within STALE_SECONDS' do
+      described_class.check_publish('stale_tenant')
+
+      # Simulate the entry being very old by backdating updated_at
+      stale_window = described_class.send(:current_window) - (described_class::STALE_SECONDS + 1)
+      described_class.instance_variable_get(:@counters)['stale_tenant'][:updated_at] = stale_window
+
+      # Trigger sweep by making another call for a different tenant
+      allow(Legion::Settings).to receive(:dig)
+        .with(:transport, :tenant_topology, :quotas, :other_tenant)
+        .and_return({ messages_per_second: 100 })
+      described_class.check_publish('other_tenant')
+
+      expect(described_class.instance_variable_get(:@counters)).not_to have_key('stale_tenant')
+    end
   end
 
   describe '.reset!' do
@@ -106,6 +148,16 @@ RSpec.describe Legion::Transport::TenantQuota do
       described_class.check_publish('abc123')
       described_class.reset!
       expect(described_class.check_publish('abc123')).to be true
+    end
+
+    it 'clears per-tenant mutexes' do
+      Legion::Settings[:transport][:tenant_topology][:enabled] = true
+      Legion::Settings[:transport][:tenant_topology][:quotas] = {
+        abc123: { messages_per_second: 10 }
+      }
+      described_class.check_publish('abc123')
+      described_class.reset!
+      expect(described_class.instance_variable_get(:@mutexes)).to be_empty
     end
   end
 

--- a/spec/legion/transport/tenant_topology_spec.rb
+++ b/spec/legion/transport/tenant_topology_spec.rb
@@ -7,10 +7,14 @@ RSpec.describe Legion::Transport::TenantTopology do
   before do
     Legion::Settings[:transport][:tenant_topology] ||= {}
     Legion::Settings[:transport][:tenant_topology][:enabled] = false
+    Legion::Settings[:transport][:tenant_topology].delete(:shared_exchanges)
+    Legion::Settings[:transport][:tenant_topology].delete(:prefix_format)
   end
 
   after do
     Legion::Settings[:transport][:tenant_topology][:enabled] = false
+    Legion::Settings[:transport][:tenant_topology].delete(:shared_exchanges)
+    Legion::Settings[:transport][:tenant_topology].delete(:prefix_format)
   end
 
   describe '.enabled?' do
@@ -30,8 +34,11 @@ RSpec.describe Legion::Transport::TenantTopology do
   end
 
   describe '.shared?' do
-    it 'returns true for legion.control prefix' do
+    it 'returns true for exact legion.control match' do
       expect(described_class.shared?('legion.control')).to be true
+    end
+
+    it 'returns true for legion.control sub-path' do
       expect(described_class.shared?('legion.control.sub')).to be true
     end
 
@@ -46,6 +53,24 @@ RSpec.describe Legion::Transport::TenantTopology do
     it 'returns false for non-shared names' do
       expect(described_class.shared?('tasks')).to be false
       expect(described_class.shared?('results')).to be false
+    end
+
+    it 'does not over-match names that merely start with a shared prefix string' do
+      expect(described_class.shared?('legion.controlled')).to be false
+      expect(described_class.shared?('legion.controls')).to be false
+    end
+
+    context 'when shared_exchanges is configured in settings' do
+      before do
+        Legion::Settings[:transport][:tenant_topology][:shared_exchanges] = %w[custom.shared another.shared]
+      end
+
+      it 'uses configured list instead of defaults' do
+        expect(described_class.shared?('custom.shared')).to be true
+        expect(described_class.shared?('another.shared')).to be true
+        expect(described_class.shared?('custom.shared.sub')).to be true
+        expect(described_class.shared?('legion.control')).to be false
+      end
     end
   end
 
@@ -83,6 +108,20 @@ RSpec.describe Legion::Transport::TenantTopology do
 
       it 'does not prefix shared exchange subnames' do
         expect(described_class.exchange_name('legion.control.something', tenant_id: 'abc123')).to eq('legion.control.something')
+      end
+
+      it 'prefixes exchanges that merely start with a shared prefix string (not a real subpath)' do
+        expect(described_class.exchange_name('legion.controlled', tenant_id: 'abc123')).to eq('t.abc123.legion.controlled')
+      end
+
+      context 'when prefix_format is configured' do
+        before do
+          Legion::Settings[:transport][:tenant_topology][:prefix_format] = 'tenants/%<tenant_id>s/%<name>s'
+        end
+
+        it 'uses the configured prefix format' do
+          expect(described_class.exchange_name('tasks', tenant_id: 'abc123')).to eq('tenants/abc123/tasks')
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary
- Isolated DLX declarations to dedicated channels — one failed declaration can't cascade to other actors
- Added self-healing `recreate_dlx` on PreconditionFailed (deletes and redeclares mismatched DLX exchanges)
- Added `exclusive: true` to Node and Agent queues for RabbitMQ 4.x (`transient_nonexcl_queues` deprecation)
- Fixed `topology_mode?` to check `worker?` instead of `agent?` — agent mode should not create topology
- DLX exchanges remain `fanout` (correct semantic for dead letter catch-all)

## Test plan
- [x] 122 files rubocop clean
- [x] Unit specs pass (integration specs require live RabbitMQ broker)
- [ ] Verify startup against new RMQ cluster with no PreconditionFailed errors
- [ ] Verify Node/Agent queues create successfully without transient_nonexcl_queues rejection