### PR TITLE
feat(transport): emit db_principal_id and db_identity_id as integer AMQP headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.4.25] - 2026-05-15
+
+### Added
+- `Message#identity_headers` now emits `x-legion-identity-db-principal-id` and `x-legion-identity-db-identity-id` as integer AMQP headers when non-nil, enabling downstream consumers (e.g. legion-apollo `inject_identity_context`) to use the DB primary keys without string parsing. Nil values are omitted.
+
 ## [1.4.24] - 2026-05-11
 
 ### Fixed

--- a/lib/legion/transport/message.rb
+++ b/lib/legion/transport/message.rb
@@ -326,7 +326,7 @@ module Legion
 
       def identity_headers
         id = Legion::Identity::Process.identity_hash
-        {
+        headers = {
           'x-legion-identity-canonical-name' => id[:canonical_name].to_s,
           'x-legion-identity-trust'          => id[:trust].to_s,
           'x-legion-identity-id'             => id[:id].to_s,
@@ -334,6 +334,9 @@ module Legion
           'x-legion-identity-mode'           => id[:mode].to_s,
           'x-legion-identity-source'         => id[:source].to_s
         }
+        headers['x-legion-identity-db-principal-id'] = id[:db_principal_id] if id[:db_principal_id]
+        headers['x-legion-identity-db-identity-id']  = id[:db_identity_id]  if id[:db_identity_id]
+        headers
       end
 
       def inject_identity_headers

--- a/lib/legion/transport/version.rb
+++ b/lib/legion/transport/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Transport
-    VERSION = '1.4.24'
+    VERSION = '1.4.25'
   end
 end

--- a/spec/legion/transport/connection/vault_spec.rb
+++ b/spec/legion/transport/connection/vault_spec.rb
@@ -19,11 +19,8 @@ RSpec.describe Legion::Transport::Connection::Vault do
 
   describe '#vault_pki_tls_options' do
     context 'when vault_pki is disabled in settings' do
-      before do
-        allow(Legion::Settings).to receive(:[]).with(:transport).and_return(
-          { tls: { vault_pki: false } }
-        )
-      end
+      before { Legion::Settings[:transport][:tls] = { vault_pki: false } }
+      after  { Legion::Settings[:transport].delete(:tls) }
 
       it 'returns empty hash' do
         expect(test_obj.vault_pki_tls_options).to eq({})
@@ -32,11 +29,10 @@ RSpec.describe Legion::Transport::Connection::Vault do
 
     context 'when vault_pki is enabled but Crypt::Mtls is not defined' do
       before do
-        allow(Legion::Settings).to receive(:[]).with(:transport).and_return(
-          { tls: { vault_pki: true } }
-        )
+        Legion::Settings[:transport][:tls] = { vault_pki: true }
         hide_const('Legion::Crypt::Mtls') if defined?(Legion::Crypt::Mtls)
       end
+      after { Legion::Settings[:transport].delete(:tls) }
 
       it 'returns empty hash' do
         expect(test_obj.vault_pki_tls_options).to eq({})
@@ -45,13 +41,12 @@ RSpec.describe Legion::Transport::Connection::Vault do
 
     context 'when vault_pki is enabled but Mtls.enabled? is false' do
       before do
-        allow(Legion::Settings).to receive(:[]).with(:transport).and_return(
-          { tls: { vault_pki: true } }
-        )
+        Legion::Settings[:transport][:tls] = { vault_pki: true }
         mtls = Module.new
         stub_const('Legion::Crypt::Mtls', mtls)
         allow(Legion::Crypt::Mtls).to receive(:enabled?).and_return(false)
       end
+      after { Legion::Settings[:transport].delete(:tls) }
 
       it 'returns empty hash' do
         expect(test_obj.vault_pki_tls_options).to eq({})
@@ -60,19 +55,17 @@ RSpec.describe Legion::Transport::Connection::Vault do
 
     context 'when vault_pki and Mtls.enabled? are both true' do
       before do
-        allow(Legion::Settings).to receive(:[]).with(:transport).and_return(
-          { tls: { vault_pki: true }, connection: { host: '127.0.0.1' } }
-        )
-        allow(Legion::Settings).to receive(:[]).with(:client).and_return({ name: 'test-node' })
+        Legion::Settings[:transport][:tls] = { vault_pki: true }
         mtls = Module.new
         stub_const('Legion::Crypt::Mtls', mtls)
         allow(Legion::Crypt::Mtls).to receive(:enabled?).and_return(true)
         allow(Legion::Crypt::Mtls).to receive(:issue_cert).and_return(cert_data)
       end
+      after { Legion::Settings[:transport].delete(:tls) }
 
       it 'calls Mtls.issue_cert with the node name' do
         expect(Legion::Crypt::Mtls).to receive(:issue_cert).with(
-          common_name: 'test-node'
+          common_name: Legion::Settings[:client][:name]
         ).and_return(cert_data)
         test_obj.vault_pki_tls_options
       end
@@ -116,15 +109,13 @@ RSpec.describe Legion::Transport::Connection::Vault do
 
     context 'when Mtls.issue_cert raises' do
       before do
-        allow(Legion::Settings).to receive(:[]).with(:transport).and_return(
-          { tls: { vault_pki: true }, connection: { host: '127.0.0.1' } }
-        )
-        allow(Legion::Settings).to receive(:[]).with(:client).and_return({ name: 'test-node' })
+        Legion::Settings[:transport][:tls] = { vault_pki: true }
         mtls = Module.new
         stub_const('Legion::Crypt::Mtls', mtls)
         allow(Legion::Crypt::Mtls).to receive(:enabled?).and_return(true)
         allow(Legion::Crypt::Mtls).to receive(:issue_cert).and_raise(RuntimeError, 'Vault unreachable')
       end
+      after { Legion::Settings[:transport].delete(:tls) }
 
       it 'returns empty hash and does not raise' do
         expect { test_obj.vault_pki_tls_options }.not_to raise_error
@@ -134,18 +125,20 @@ RSpec.describe Legion::Transport::Connection::Vault do
   end
 
   describe '#vault_pki_enabled?' do
+    after { Legion::Settings[:transport].delete(:tls) }
+
     it 'returns false when transport.tls.vault_pki is false' do
-      allow(Legion::Settings).to receive(:[]).with(:transport).and_return({ tls: { vault_pki: false } })
+      Legion::Settings[:transport][:tls] = { vault_pki: false }
       expect(test_obj.vault_pki_enabled?).to be false
     end
 
     it 'returns false when tls key is missing' do
-      allow(Legion::Settings).to receive(:[]).with(:transport).and_return({})
+      Legion::Settings[:transport].delete(:tls)
       expect(test_obj.vault_pki_enabled?).to be false
     end
 
     it 'returns true when vault_pki is true' do
-      allow(Legion::Settings).to receive(:[]).with(:transport).and_return({ tls: { vault_pki: true } })
+      Legion::Settings[:transport][:tls] = { vault_pki: true }
       expect(test_obj.vault_pki_enabled?).to be true
     end
   end

--- a/spec/legion/transport/message_identity_headers_spec.rb
+++ b/spec/legion/transport/message_identity_headers_spec.rb
@@ -56,4 +56,40 @@ RSpec.describe 'Identity headers' do
     expect { msg.headers }.not_to raise_error
     expect(msg.headers['preserve']).to eq('me')
   end
+
+  context 'with db integer identity fields' do
+    let(:identity_hash_with_db_ids) do
+      {
+        canonical_name:  'agent.local',
+        id:              'abc-123',
+        kind:            'agent',
+        mode:            'prod',
+        source:          'gaia',
+        db_principal_id: 42,
+        db_identity_id:  99
+      }
+    end
+
+    before do
+      Legion::Identity::Process.identity_hash_value = identity_hash_with_db_ids
+      Legion::Identity::Process.resolved_flag = true
+    end
+
+    it 'emits x-legion-identity-db-principal-id as integer' do
+      msg = message_class.new(function: 'test')
+      expect(msg.headers['x-legion-identity-db-principal-id']).to eq(42)
+    end
+
+    it 'emits x-legion-identity-db-identity-id as integer' do
+      msg = message_class.new(function: 'test')
+      expect(msg.headers['x-legion-identity-db-identity-id']).to eq(99)
+    end
+
+    it 'omits db headers when values are nil' do
+      Legion::Identity::Process.identity_hash_value = identity_hash.merge(db_principal_id: nil, db_identity_id: nil)
+      msg = message_class.new(function: 'test')
+      expect(msg.headers).not_to have_key('x-legion-identity-db-principal-id')
+      expect(msg.headers).not_to have_key('x-legion-identity-db-identity-id')
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- `Message#identity_headers` now emits `x-legion-identity-db-principal-id` and `x-legion-identity-db-identity-id` as integers (not strings) when non-nil
- Nil values are omitted from headers — no change to messages published before identity is resolved or before lex-identity-* extensions populate the DB PKs

## Prerequisites

LegionIO `Identity::Process` PR merged (Identity::Process must expose `db_principal_id` and `db_identity_id` in `identity_hash`).

## Test plan

- [ ] Integer headers emitted when db_principal_id and db_identity_id are non-nil
- [ ] Headers omitted when values are nil
- [ ] All existing message header examples pass