### PR TITLE
fix(transport): sweep orphaned channels from dead IO-pool threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [1.4.26] - 2026-05-16
+
+### Fixed
+- Fixed channel leak caused by concurrent-ruby's IO-pool thread lifecycle: `TimerTask` (used by `Every` actors) dispatches onto `global_io_executor` threads that idle-timeout after 60s; thread-local Bunny channels were never closed when those threads died, eventually exhausting RabbitMQ's `channel_max` (1024). Added a `@channel_registry` that tracks publisher channels by owning thread and sweeps orphaned channels from dead threads before creating new ones.
+- `Connection.shutdown` now explicitly closes all tracked publisher channels before tearing down the session.
+- `Connection.force_reconnect` resets the channel registry to prevent stale references after reconnection.
+
 ## [1.4.25] - 2026-05-15
 
 ### Added

--- a/lib/legion/transport/connection.rb
+++ b/lib/legion/transport/connection.rb
@@ -87,6 +87,12 @@ module Legion
 
           sweep_dead_thread_channels
 
+          current_size = channel_registry_size
+          if current_size >= MAX_PUBLISHER_CHANNELS
+            log.warn "Channel registry at capacity (size=#{current_size}, max=#{MAX_PUBLISHER_CHANNELS}); " \
+                     'RabbitMQ channel_max exhaustion risk — investigate thread lifecycle'
+          end
+
           @channel_thread.value = s.create_channel(nil, settings[:channel][:default_worker_pool_size], false, 10)
           @channel_thread.value.prefetch(settings[:prefetch])
           track_channel(Thread.current, @channel_thread.value)

--- a/lib/legion/transport/connection.rb
+++ b/lib/legion/transport/connection.rb
@@ -11,6 +11,7 @@ module Legion
     module Connection
       RECOVERY_WINDOW = 60
       MAX_RECOVERIES_PER_WINDOW = 5
+      MAX_PUBLISHER_CHANNELS = 128
 
       class << self
         include Legion::Logging::Helper
@@ -36,6 +37,7 @@ module Legion
         def reconnect(connection_name: 'Legion', **)
           @session = nil
           @channel_thread = Concurrent::ThreadLocalVar.new(nil)
+          @channel_registry = Concurrent::Hash.new
           setup(connection_name: connection_name)
         end
 
@@ -83,9 +85,12 @@ module Legion
           s = session
           raise IOError, 'transport session unavailable (recovery in progress)' unless s&.open?
 
+          sweep_dead_thread_channels
+
           @channel_thread.value = s.create_channel(nil, settings[:channel][:default_worker_pool_size], false, 10)
           @channel_thread.value.prefetch(settings[:prefetch])
-          log.debug "Channel created for thread #{Thread.current.object_id}"
+          track_channel(Thread.current, @channel_thread.value)
+          log.debug "Channel created for thread #{Thread.current.object_id} (tracked=#{channel_registry_size})"
           @channel_thread.value
         end
 
@@ -127,6 +132,7 @@ module Legion
           @shutting_down = true
           pre_mark_sessions_closing
           close_build_session
+          close_all_tracked_channels
 
           if @pool
             @pool.shutdown
@@ -150,6 +156,7 @@ module Legion
         ensure
           @log_channel = nil
           @session = nil
+          @channel_registry = Concurrent::Hash.new
           @shutting_down = false
         end
 
@@ -163,6 +170,7 @@ module Legion
           reset_pool if pool_mode
           @session = nil
           @channel_thread = Concurrent::ThreadLocalVar.new(nil)
+          @channel_registry = Concurrent::Hash.new
           @recovery_timestamps = []
 
           tear_down_session(old) if old && !pool_mode
@@ -272,7 +280,49 @@ module Legion
           sess
         end
 
+        def channel_registry_size
+          (@channel_registry ||= Concurrent::Hash.new).size
+        end
+
         private
+
+        def track_channel(thread, channel)
+          @channel_registry ||= Concurrent::Hash.new
+          @channel_registry[thread] = channel
+        end
+
+        def close_all_tracked_channels
+          @channel_registry ||= Concurrent::Hash.new
+          return if @channel_registry.empty?
+
+          @channel_registry.each_value do |channel|
+            channel.close if channel&.open?
+          rescue StandardError => e
+            handle_exception(e, level: :warn, handled: true, operation: 'transport.connection.close_tracked_channel')
+          end
+          @channel_registry.clear
+        end
+
+        def sweep_dead_thread_channels
+          @channel_registry ||= Concurrent::Hash.new
+          return if @channel_registry.empty?
+
+          swept = 0
+          @channel_registry.each do |thread, channel|
+            next if thread&.alive?
+
+            if channel&.open?
+              channel.close
+              swept += 1
+            end
+            @channel_registry.delete(thread)
+          rescue StandardError => e
+            @channel_registry.delete(thread)
+            handle_exception(e, level: :warn, handled: true, operation: 'transport.connection.sweep_channel')
+          end
+
+          log.info "Swept #{swept} orphaned channel(s) from dead threads (remaining=#{@channel_registry.size})" if swept.positive?
+        end
 
         def pre_mark_sessions_closing
           candidates = [
@@ -493,6 +543,7 @@ module Legion
           @log_channel = nil
           @session = Concurrent::AtomicReference.new(create_session_with_failover(connection_name: connection_name))
           @channel_thread = Concurrent::ThreadLocalVar.new(nil)
+          @channel_registry = Concurrent::Hash.new
           start_session(session)
           qos_channel = session.create_channel(nil, settings[:channel][:session_worker_pool_size])
           apply_qos_and_close(qos_channel)

--- a/lib/legion/transport/version.rb
+++ b/lib/legion/transport/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Transport
-    VERSION = '1.4.25'
+    VERSION = '1.4.26'
   end
 end

--- a/spec/legion/transport/connection_dead_thread_sweep_spec.rb
+++ b/spec/legion/transport/connection_dead_thread_sweep_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Connection dead-thread channel sweep' do
+  let(:connection) { Legion::Transport::Connection }
+
+  before do
+    connection.instance_variable_set(:@channel_registry, Concurrent::Hash.new)
+  end
+
+  after do
+    connection.instance_variable_set(:@channel_registry, Concurrent::Hash.new)
+  end
+
+  describe '#sweep_dead_thread_channels' do
+    it 'closes channels from dead threads' do
+      channel = instance_double('Bunny::Channel', open?: true)
+      dead_thread = instance_double('Thread', alive?: false)
+
+      registry = connection.instance_variable_get(:@channel_registry)
+      registry[dead_thread] = channel
+
+      expect(channel).to receive(:close)
+      connection.send(:sweep_dead_thread_channels)
+      expect(registry).to be_empty
+    end
+
+    it 'does not close channels from live threads' do
+      channel = instance_double('Bunny::Channel', open?: true)
+      live_thread = instance_double('Thread', alive?: true)
+
+      registry = connection.instance_variable_get(:@channel_registry)
+      registry[live_thread] = channel
+
+      expect(channel).not_to receive(:close)
+      connection.send(:sweep_dead_thread_channels)
+      expect(registry.size).to eq(1)
+    end
+
+    it 'removes dead-thread entries even when channel is already closed' do
+      channel = instance_double('Bunny::Channel', open?: false)
+      dead_thread = instance_double('Thread', alive?: false)
+
+      registry = connection.instance_variable_get(:@channel_registry)
+      registry[dead_thread] = channel
+
+      connection.send(:sweep_dead_thread_channels)
+      expect(registry).to be_empty
+    end
+
+    it 'handles channel.close raising an exception' do
+      channel = instance_double('Bunny::Channel', open?: true)
+      dead_thread = instance_double('Thread', alive?: false)
+      allow(channel).to receive(:close).and_raise(RuntimeError, 'already closed')
+
+      registry = connection.instance_variable_get(:@channel_registry)
+      registry[dead_thread] = channel
+
+      expect { connection.send(:sweep_dead_thread_channels) }.not_to raise_error
+      expect(registry).to be_empty
+    end
+  end
+
+  describe '#track_channel' do
+    it 'registers the thread and channel' do
+      channel = instance_double('Bunny::Channel')
+      thread = Thread.current
+
+      connection.send(:track_channel, thread, channel)
+      registry = connection.instance_variable_get(:@channel_registry)
+      expect(registry[thread]).to eq(channel)
+    end
+  end
+
+  describe '#close_all_tracked_channels' do
+    it 'closes all tracked channels and clears the registry' do
+      ch1 = instance_double('Bunny::Channel', open?: true)
+      ch2 = instance_double('Bunny::Channel', open?: true)
+      t1 = instance_double('Thread')
+      t2 = instance_double('Thread')
+
+      registry = connection.instance_variable_get(:@channel_registry)
+      registry[t1] = ch1
+      registry[t2] = ch2
+
+      expect(ch1).to receive(:close)
+      expect(ch2).to receive(:close)
+
+      connection.send(:close_all_tracked_channels)
+      expect(registry).to be_empty
+    end
+  end
+
+  describe '#channel_registry_size' do
+    it 'returns the number of tracked channels' do
+      registry = connection.instance_variable_get(:@channel_registry)
+      registry[Thread.current] = nil
+      registry[instance_double('Thread')] = nil
+
+      expect(connection.channel_registry_size).to eq(2)
+    end
+  end
+
+  describe 'integration: threads that die release channels' do
+    it 'sweeps channels from threads that have terminated' do
+      channel = instance_double('Bunny::Channel', open?: true)
+      dead_thread = Thread.new { nil }
+      dead_thread.join
+
+      registry = connection.instance_variable_get(:@channel_registry)
+      registry[dead_thread] = channel
+
+      expect(channel).to receive(:close)
+      connection.send(:sweep_dead_thread_channels)
+      expect(registry).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Fixed channel leak caused by concurrent-ruby's IO-pool thread lifecycle: `TimerTask` (used by `Every` actors) dispatches onto `global_io_executor` threads that idle-timeout after 60s; thread-local Bunny channels were never closed when those threads died, eventually exhausting RabbitMQ's `channel_max` (1024)
- Added `@channel_registry` (keyed by Thread → channel) that sweeps orphaned channels from dead threads before creating new ones
- `shutdown` and `force_reconnect` now clean up all tracked channels

## Root Cause

```
Every actor tick → TimerTask → global_io_executor (unbounded pool, 60s idle)
  → new worker thread → Connection.channel → ThreadLocalVar caches Bunny channel
  → thread idle-timeouts and dies → channel never closed → session tracks it forever
  → repeat ~1000x → channel_max exhausted
```

## Test plan

- [x] New spec: `connection_dead_thread_sweep_spec.rb` (8 examples) covers sweep, track, close_all, registry_size, and real dead-thread integration
- [x] Full `bundle exec rspec` — 720 examples, 31 failures (all pre-existing: no local RabbitMQ)
- [x] Full `bundle exec rubocop` — 123 files, 0 offenses
- [ ] Deploy and confirm `Swept N orphaned channel(s)` log messages appear at INFO level
- [ ] Confirm channel count stabilizes below 128 under sustained timer load