### PR TITLE
fix(transport): race condition in channel registry iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.4.27] - 2026-05-17
+
+### Fixed
+- Fixed race condition in channel registry iteration: `sweep_dead_thread_channels` and `close_all_tracked_channels` used `.each` on the live hash while parallel boot threads (`hook_subscription_actors_pooled`) concurrently called `track_channel`, raising `"can't add a new key into hash during iteration"` on Ruby 3.4. Replaced with `.keys.each` which snapshots the key list into an Array before iterating.
+
 ## [1.4.26] - 2026-05-16
 
 ### Fixed

--- a/lib/legion/transport/connection.rb
+++ b/lib/legion/transport/connection.rb
@@ -301,12 +301,12 @@ module Legion
           @channel_registry ||= Concurrent::Hash.new
           return if @channel_registry.empty?
 
-          @channel_registry.each_value do |channel|
-            channel.close if channel&.open?
+          @channel_registry.keys.each do |thread| # rubocop:disable Style/HashEachMethods
+            channel = @channel_registry.delete(thread)
+            channel&.close if channel&.open?
           rescue StandardError => e
             handle_exception(e, level: :warn, handled: true, operation: 'transport.connection.close_tracked_channel')
           end
-          @channel_registry.clear
         end
 
         def sweep_dead_thread_channels
@@ -314,14 +314,16 @@ module Legion
           return if @channel_registry.empty?
 
           swept = 0
-          @channel_registry.each do |thread, channel|
+          @channel_registry.keys.each do |thread| # rubocop:disable Style/HashEachMethods
             next if thread&.alive?
 
-            if channel&.open?
+            channel = @channel_registry.delete(thread)
+            next unless channel
+
+            if channel.open?
               channel.close
               swept += 1
             end
-            @channel_registry.delete(thread)
           rescue StandardError => e
             @channel_registry.delete(thread)
             handle_exception(e, level: :warn, handled: true, operation: 'transport.connection.sweep_channel')

--- a/lib/legion/transport/version.rb
+++ b/lib/legion/transport/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Transport
-    VERSION = '1.4.26'
+    VERSION = '1.4.27'
   end
 end


### PR DESCRIPTION
## Summary

- Hotfix for runtime crash introduced in v1.4.26 (PR #35): `"can't add a new key into hash during iteration"` during parallel boot
- `sweep_dead_thread_channels` and `close_all_tracked_channels` used `.each` on the live registry hash while `hook_subscription_actors_pooled` concurrently called `track_channel` from other threads
- Replaced `.each` / `.each_value` with `.keys.each` which creates a snapshot Array — safe to iterate while other threads mutate the underlying `Concurrent::Hash`

## Affected extensions (all hit during boot)

- lex-exec (bundler, shell actors)
- lex-openai (chat, files, models actors)
- lex-gemini (cached_contents, embeddings actors)

## Test plan

- [x] `connection_dead_thread_sweep_spec.rb` — 8 examples, 0 failures
- [x] `bundle exec rubocop` — 0 offenses
- [ ] Deploy and confirm no iteration errors during parallel boot