### PR TITLE
fix(transport): skip sweeping channels with active consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [1.4.28] - 2026-05-17
+
+### Fixed
+- Fixed sweep closing channels that still have active Bunny consumers: subscription actors are instantiated on pool threads that subsequently die, but the channel is handed off to Bunny's `ConsumerWorkPool`. The sweep now checks `channel.consumers` and skips channels with registered consumers.
+
+## [1.4.27] - 2026-05-17
+
+### Fixed
+- Fixed race condition in channel registry iteration: `.each` on the live hash raised `"can't add a new key into hash during iteration"` when parallel boot threads called `track_channel` concurrently. Replaced with `.keys.each` snapshot.
+
 ## [1.4.26] - 2026-05-16
 
 ### Fixed

--- a/lib/legion/transport/connection.rb
+++ b/lib/legion/transport/connection.rb
@@ -336,7 +336,8 @@ module Legion
           return false unless channel.respond_to?(:consumers)
 
           !channel.consumers.empty?
-        rescue StandardError
+        rescue StandardError => e
+          handle_exception(e, level: :debug, handled: true, operation: 'transport.connection.channel_has_consumers?')
           false
         end
 

--- a/lib/legion/transport/connection.rb
+++ b/lib/legion/transport/connection.rb
@@ -301,12 +301,12 @@ module Legion
           @channel_registry ||= Concurrent::Hash.new
           return if @channel_registry.empty?
 
-          @channel_registry.each_value do |channel|
-            channel.close if channel&.open?
+          @channel_registry.keys.each do |thread| # rubocop:disable Style/HashEachMethods
+            channel = @channel_registry.delete(thread)
+            channel&.close if channel&.open?
           rescue StandardError => e
             handle_exception(e, level: :warn, handled: true, operation: 'transport.connection.close_tracked_channel')
           end
-          @channel_registry.clear
         end
 
         def sweep_dead_thread_channels
@@ -314,20 +314,30 @@ module Legion
           return if @channel_registry.empty?
 
           swept = 0
-          @channel_registry.each do |thread, channel|
+          @channel_registry.keys.each do |thread| # rubocop:disable Style/HashEachMethods
             next if thread&.alive?
 
-            if channel&.open?
-              channel.close
-              swept += 1
-            end
-            @channel_registry.delete(thread)
+            channel = @channel_registry.delete(thread)
+            next unless channel
+            next unless channel.open?
+            next if channel_has_consumers?(channel)
+
+            channel.close
+            swept += 1
           rescue StandardError => e
             @channel_registry.delete(thread)
             handle_exception(e, level: :warn, handled: true, operation: 'transport.connection.sweep_channel')
           end
 
           log.info "Swept #{swept} orphaned channel(s) from dead threads (remaining=#{@channel_registry.size})" if swept.positive?
+        end
+
+        def channel_has_consumers?(channel)
+          return false unless channel.respond_to?(:consumers)
+
+          !channel.consumers.empty?
+        rescue StandardError
+          false
         end
 
         def pre_mark_sessions_closing

--- a/lib/legion/transport/version.rb
+++ b/lib/legion/transport/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Transport
-    VERSION = '1.4.26'
+    VERSION = '1.4.28'
   end
 end

--- a/spec/legion/transport/connection_dead_thread_sweep_spec.rb
+++ b/spec/legion/transport/connection_dead_thread_sweep_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe 'Connection dead-thread channel sweep' do
   end
 
   describe '#sweep_dead_thread_channels' do
-    it 'closes channels from dead threads' do
-      channel = instance_double('Bunny::Channel', open?: true)
+    it 'closes channels from dead threads with no consumers' do
+      channel = instance_double('Bunny::Channel', open?: true, consumers: {})
       dead_thread = instance_double('Thread', alive?: false)
 
       registry = connection.instance_variable_get(:@channel_registry)
@@ -38,6 +38,19 @@ RSpec.describe 'Connection dead-thread channel sweep' do
       expect(registry.size).to eq(1)
     end
 
+    it 'does not close channels with active consumers even if thread is dead' do
+      consumer = instance_double('Bunny::Consumer')
+      channel = instance_double('Bunny::Channel', open?: true, consumers: { 'tag' => consumer })
+      dead_thread = instance_double('Thread', alive?: false)
+
+      registry = connection.instance_variable_get(:@channel_registry)
+      registry[dead_thread] = channel
+
+      expect(channel).not_to receive(:close)
+      connection.send(:sweep_dead_thread_channels)
+      expect(registry).to be_empty
+    end
+
     it 'removes dead-thread entries even when channel is already closed' do
       channel = instance_double('Bunny::Channel', open?: false)
       dead_thread = instance_double('Thread', alive?: false)
@@ -50,7 +63,7 @@ RSpec.describe 'Connection dead-thread channel sweep' do
     end
 
     it 'handles channel.close raising an exception' do
-      channel = instance_double('Bunny::Channel', open?: true)
+      channel = instance_double('Bunny::Channel', open?: true, consumers: {})
       dead_thread = instance_double('Thread', alive?: false)
       allow(channel).to receive(:close).and_raise(RuntimeError, 'already closed')
 
@@ -104,7 +117,7 @@ RSpec.describe 'Connection dead-thread channel sweep' do
 
   describe 'integration: threads that die release channels' do
     it 'sweeps channels from threads that have terminated' do
-      channel = instance_double('Bunny::Channel', open?: true)
+      channel = instance_double('Bunny::Channel', open?: true, consumers: {})
       dead_thread = Thread.new { nil }
       dead_thread.join
 


### PR DESCRIPTION
## Summary

- Fixed sweep closing channels that still have active Bunny consumers, causing `ChannelAlreadyClosed` on `basic_ack` during boot
- Subscription actors are instantiated on pool threads (via `hook_subscription_actors_pooled`) that die after setup, but the channel is handed off to Bunny's `ConsumerWorkPool` — the sweep was incorrectly treating these as orphaned
- `sweep_dead_thread_channels` now checks `channel.consumers` and skips channels with registered consumers
- Also includes the `.keys.each` snapshot fix from PR #36 (iteration race)

## Symptoms (from v1.4.26/1.4.27)

- `[Subscription] channel closed before activate` warnings across many extensions during boot
- `Bunny::ChannelAlreadyClosed: cannot use a closed channel! Channel id: 14` on `basic_ack`
- Affected: lex-lex, lex-audit, lex-conditioner, lex-scheduler, lex-github, lex-openai, lex-gemini

## Test plan

- [x] `connection_dead_thread_sweep_spec.rb` — 9 examples, 0 failures (includes consumer-guard test)
- [x] `bundle exec rubocop` — 0 offenses
- [ ] Deploy and confirm no `ChannelAlreadyClosed` errors during boot
- [ ] Confirm sweep only closes truly orphaned publisher channels (no consumers)