### PR TITLE
Add Legion version to message headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.4.29] - 2026-05-22
+
+### Added
+- `Message#headers` now emits best-effort `x-legion-version` when `Legion::VERSION` is loaded, alongside the existing `legion_protocol_version` protocol marker.
+
 ## [1.4.28] - 2026-05-17
 
 ### Fixed

--- a/lib/legion/transport/message.rb
+++ b/lib/legion/transport/message.rb
@@ -7,6 +7,8 @@ module Legion
     class Message
       include Legion::Transport::Common
 
+      LEGION_PROTOCOL_VERSION = '2.0'
+
       class << self
         include Legion::Logging::Helper
       end
@@ -258,7 +260,8 @@ module Legion
 
       def headers
         @options[:headers] ||= Concurrent::Hash.new
-        @options[:headers]['legion_protocol_version'] ||= '2.0'
+        @options[:headers]['legion_protocol_version'] ||= LEGION_PROTOCOL_VERSION
+        inject_legion_version_header
         inject_region_header
         inject_legion_region_header
         %i[task_id relationship_id trigger_namespace_id trigger_function_id parent_id master_id runner_namespace runner_class namespace_id function_id function
@@ -345,6 +348,12 @@ module Legion
         @options[:headers].merge!(identity_headers)
       rescue LoadError, StandardError => e
         handle_exception(e, level: :warn, handled: true, operation: 'transport.message.inject_identity_headers')
+      end
+
+      def inject_legion_version_header
+        return unless defined?(Legion::VERSION)
+
+        @options[:headers]['x-legion-version'] ||= Legion::VERSION.to_s
       end
 
       def inject_region_header

--- a/lib/legion/transport/version.rb
+++ b/lib/legion/transport/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Transport
-    VERSION = '1.4.28'
+    VERSION = '1.4.29'
   end
 end

--- a/spec/legion/transport/message_protocol_version_spec.rb
+++ b/spec/legion/transport/message_protocol_version_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe 'Protocol version header' do
     expect(msg.headers).to include('legion_protocol_version' => '2.0')
   end
 
+  it 'includes x-legion-version when Legion::VERSION is loaded' do
+    stub_const('Legion::VERSION', '1.9.99')
+    msg = message_class.new(function: 'test')
+    expect(msg.headers).to include('x-legion-version' => '1.9.99')
+  end
+
   it 'preserves existing headers alongside protocol version' do
     msg = message_class.new(function: 'test', task_id: 42)
     hdrs = msg.headers


### PR DESCRIPTION
## Summary
- Adds best-effort x-legion-version to Legion::Transport::Message headers when Legion::VERSION is loaded.
- Keeps the existing legion_protocol_version protocol marker intact.
- Bumps legion-transport to 1.4.29 and adds regression coverage.

## Verification
- bundle exec rspec --format json --out tmp/rspec_results.json --format progress --out tmp/rspec_progress.txt
- bundle exec rubocop -A