### PR TITLE
Fix AMQP DLX channel recovery loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.4.30] - 2026-07-31
+
+### Fixed
+- Fixed DLX recovery loop (`Bunny::ChannelAlreadyClosed` on `legion.*.dlx` exchanges and queues). The `declare_dlx` method recorded DLX topology on a short-lived channel that was immediately closed after declaration; Bunny's automatic recovery then repeatedly attempted to re-declare on the dead channel, looping forever. Now uses `exchange_declare_without_recording_topology` and `queue_declare_without_recording_topology` so the DLX (durable on the server) is not tracked for client-side recovery. Also added explicit `ChannelAlreadyClosed` handling in `ensure_dlx` and `recreate_dlx` to fail once with context instead of looping.
+
 ## [1.4.29] - 2026-05-22
 
 ### Added

--- a/lib/legion/transport/queue.rb
+++ b/lib/legion/transport/queue.rb
@@ -89,12 +89,18 @@ module Legion
         dlx_name = merged_options.dig(:arguments, :'x-dead-letter-exchange')
         return if dlx_name.nil? || dlx_name.empty?
 
+        session = Legion::Transport::Connection.session
+        return unless session&.open?
+
         dlx_ch = nil
-        dlx_ch = Legion::Transport::Connection.session.create_channel
+        dlx_ch = session.create_channel
         declare_dlx(dlx_name, dlx_ch)
       rescue Legion::Transport::CONNECTOR::PreconditionFailed => e
         handle_exception(e, level: :warn, handled: true, operation: 'transport.queue.ensure_dlx', dlx: dlx_name)
         recreate_dlx(dlx_name)
+      rescue Legion::Transport::CONNECTOR::ChannelAlreadyClosed => e
+        handle_exception(e, level: :warn, handled: true, operation: 'transport.queue.ensure_dlx',
+                         dlx: dlx_name, detail: 'channel closed during DLX declaration')
       rescue StandardError => e
         handle_exception(e, level: :warn, handled: true, operation: 'transport.queue.ensure_dlx', dlx: dlx_name)
       ensure
@@ -102,9 +108,9 @@ module Legion
       end
 
       def declare_dlx(dlx_name, dlx_channel)
-        dlx_channel.exchange_declare(dlx_name, 'fanout', durable: true, auto_delete: false)
-        dlx_channel.queue_declare("#{dlx_name}.queue", durable: true, auto_delete: false,
-                                                       arguments: { 'x-queue-type': 'classic' })
+        dlx_channel.exchange_declare_without_recording_topology(dlx_name, 'fanout', durable: true, auto_delete: false)
+        dlx_channel.queue_declare_without_recording_topology("#{dlx_name}.queue", durable: true, auto_delete: false,
+                                                                                  arguments: { 'x-queue-type': 'classic' })
         dlx_channel.queue_bind("#{dlx_name}.queue", dlx_name, routing_key: '#')
       end
 
@@ -116,6 +122,9 @@ module Legion
         ch.close
         ch = Legion::Transport::Connection.session.create_channel
         declare_dlx(dlx_name, ch)
+      rescue Legion::Transport::CONNECTOR::ChannelAlreadyClosed => e
+        handle_exception(e, level: :error, handled: true, operation: 'transport.queue.recreate_dlx',
+                         dlx: dlx_name, detail: 'session channel unavailable during DLX recreation')
       rescue StandardError => e
         handle_exception(e, level: :warn, handled: true, operation: 'transport.queue.recreate_dlx', dlx: dlx_name)
       ensure

--- a/lib/legion/transport/version.rb
+++ b/lib/legion/transport/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Transport
-    VERSION = '1.4.29'
+    VERSION = '1.4.30'
   end
 end

--- a/spec/legion/transport/queue_passive_spec.rb
+++ b/spec/legion/transport/queue_passive_spec.rb
@@ -245,8 +245,8 @@ RSpec.describe 'Queue passive declares (credential scoping)' do
   describe '#ensure_dlx' do
     let(:channel_double) do
       dbl = instance_double('Bunny::Channel')
-      allow(dbl).to receive(:exchange_declare)
-      allow(dbl).to receive(:queue_declare)
+      allow(dbl).to receive(:exchange_declare_without_recording_topology)
+      allow(dbl).to receive(:queue_declare_without_recording_topology)
       allow(dbl).to receive(:queue_bind)
       allow(dbl).to receive(:open?).and_return(false)
       dbl
@@ -255,6 +255,7 @@ RSpec.describe 'Queue passive declares (credential scoping)' do
     before do
       session_double = instance_double('Bunny::Session')
       allow(session_double).to receive(:create_channel).and_return(channel_double)
+      allow(session_double).to receive(:open?).and_return(true)
       allow(Legion::Transport::Connection).to receive(:session).and_return(session_double)
       allow(instance).to receive(:safely_close_channel)
     end
@@ -265,7 +266,7 @@ RSpec.describe 'Queue passive declares (credential scoping)' do
       it 'creates the DLX exchange and queue' do
         merged_options = { arguments: { 'x-dead-letter-exchange': 'github.dlx' } }
         instance.ensure_dlx(merged_options)
-        expect(channel_double).to have_received(:exchange_declare).with('github.dlx', 'fanout', anything)
+        expect(channel_double).to have_received(:exchange_declare_without_recording_topology).with('github.dlx', 'fanout', anything)
       end
     end
 
@@ -277,7 +278,7 @@ RSpec.describe 'Queue passive declares (credential scoping)' do
         stub_mode(infra: true, agent: false)
         merged_options = { arguments: { 'x-dead-letter-exchange': 'github.dlx' } }
         instance.ensure_dlx(merged_options)
-        expect(channel_double).not_to have_received(:exchange_declare)
+        expect(channel_double).not_to have_received(:exchange_declare_without_recording_topology)
       end
 
       it 'skips DLX creation for worker mode' do
@@ -285,7 +286,7 @@ RSpec.describe 'Queue passive declares (credential scoping)' do
         stub_mode(infra: false, agent: false)
         merged_options = { arguments: { 'x-dead-letter-exchange': 'github.dlx' } }
         instance.ensure_dlx(merged_options)
-        expect(channel_double).not_to have_received(:exchange_declare)
+        expect(channel_double).not_to have_received(:exchange_declare_without_recording_topology)
       end
 
       it 'creates DLX for infra mode after identity resolves' do
@@ -293,7 +294,7 @@ RSpec.describe 'Queue passive declares (credential scoping)' do
         stub_mode(infra: true, agent: false)
         merged_options = { arguments: { 'x-dead-letter-exchange': 'github.dlx' } }
         instance.ensure_dlx(merged_options)
-        expect(channel_double).to have_received(:exchange_declare).with('github.dlx', 'fanout', anything)
+        expect(channel_double).to have_received(:exchange_declare_without_recording_topology).with('github.dlx', 'fanout', anything)
       end
 
       it 'skips DLX creation for agent mode (agent is not topology owner)' do
@@ -301,7 +302,7 @@ RSpec.describe 'Queue passive declares (credential scoping)' do
         stub_mode(infra: false, agent: true)
         merged_options = { arguments: { 'x-dead-letter-exchange': 'github.dlx' } }
         instance.ensure_dlx(merged_options)
-        expect(channel_double).not_to have_received(:exchange_declare)
+        expect(channel_double).not_to have_received(:exchange_declare_without_recording_topology)
       end
     end
   end

--- a/spec/queue_dlx_recovery_spec.rb
+++ b/spec/queue_dlx_recovery_spec.rb
@@ -55,10 +55,19 @@ RSpec.describe 'Queue DLX channel recovery' do
     end
 
     context 'when the created channel is already closed' do
+      let(:channel_closed_error) do
+        klass = Legion::Transport::CONNECTOR::ChannelAlreadyClosed
+        if klass.instance_method(:initialize).arity.abs > 1
+          klass.new('cannot use a closed channel', closed_channel)
+        else
+          klass.new('cannot use a closed channel')
+        end
+      end
+
       before do
         allow(Legion::Transport::Connection).to receive(:session).and_return(closed_session)
         allow(closed_channel).to receive(:exchange_declare_without_recording_topology)
-          .and_raise(Legion::Transport::CONNECTOR::ChannelAlreadyClosed.new('cannot use a closed channel'))
+          .and_raise(channel_closed_error)
       end
 
       it 'handles the error without looping' do

--- a/spec/queue_dlx_recovery_spec.rb
+++ b/spec/queue_dlx_recovery_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Queue DLX channel recovery' do
+  let(:queue_instance) { Legion::Transport::Queue.allocate }
+
+  let(:mock_session) do
+    instance_double('Bunny::Session', open?: true, create_channel: mock_channel)
+  end
+
+  let(:mock_channel) do
+    instance_double('Bunny::Channel', open?: true, close: nil).tap do |ch|
+      allow(ch).to receive(:exchange_declare_without_recording_topology)
+      allow(ch).to receive(:queue_declare_without_recording_topology)
+      allow(ch).to receive(:queue_bind)
+    end
+  end
+
+  before do
+    allow(Legion::Transport::Connection).to receive(:session).and_return(mock_session)
+  end
+
+  describe '#declare_dlx' do
+    it 'uses exchange_declare_without_recording_topology to avoid recovery tracking' do
+      queue_instance.declare_dlx('test.dlx', mock_channel)
+
+      expect(mock_channel).to have_received(:exchange_declare_without_recording_topology)
+        .with('test.dlx', 'fanout', durable: true, auto_delete: false)
+    end
+
+    it 'uses queue_declare_without_recording_topology to avoid recovery tracking' do
+      queue_instance.declare_dlx('test.dlx', mock_channel)
+
+      expect(mock_channel).to have_received(:queue_declare_without_recording_topology)
+        .with('test.dlx.queue', durable: true, auto_delete: false,
+                                arguments: { 'x-queue-type': 'classic' })
+    end
+
+    it 'binds the DLX queue to the DLX exchange' do
+      queue_instance.declare_dlx('test.dlx', mock_channel)
+
+      expect(mock_channel).to have_received(:queue_bind)
+        .with('test.dlx.queue', 'test.dlx', routing_key: '#')
+    end
+  end
+
+  describe '#ensure_dlx' do
+    let(:closed_channel) do
+      instance_double('Bunny::Channel', open?: false, close: nil)
+    end
+
+    let(:closed_session) do
+      instance_double('Bunny::Session', open?: true, create_channel: closed_channel)
+    end
+
+    context 'when the created channel is already closed' do
+      before do
+        allow(Legion::Transport::Connection).to receive(:session).and_return(closed_session)
+        allow(closed_channel).to receive(:exchange_declare_without_recording_topology)
+          .and_raise(Legion::Transport::CONNECTOR::ChannelAlreadyClosed.new('cannot use a closed channel'))
+      end
+
+      it 'handles the error without looping' do
+        merged = { arguments: { 'x-dead-letter-exchange': 'test.dlx' } }
+        expect { queue_instance.ensure_dlx(merged) }.not_to raise_error
+      end
+    end
+
+    context 'when the session is not open' do
+      before do
+        allow(Legion::Transport::Connection).to receive(:session).and_return(
+          instance_double('Bunny::Session', open?: false)
+        )
+      end
+
+      it 'returns early without attempting DLX declaration' do
+        merged = { arguments: { 'x-dead-letter-exchange': 'test.dlx' } }
+        queue_instance.ensure_dlx(merged)
+
+        expect(mock_session).not_to have_received(:create_channel)
+      end
+    end
+
+    context 'when DLX name is nil' do
+      it 'returns early' do
+        merged = { arguments: {} }
+        expect { queue_instance.ensure_dlx(merged) }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Fixed tight error loop: `Bunny::ChannelAlreadyClosed` on `legion.*.dlx` exchanges and queues during automatic recovery
- Root cause: `declare_dlx` used `exchange_declare`/`queue_declare` which record topology on a dedicated channel that is immediately closed after declaration. Bunny's recovery then repeatedly attempts to re-declare on the dead channel.
- Fix: use `exchange_declare_without_recording_topology` and `queue_declare_without_recording_topology` so durable DLX entities are not tracked for client-side recovery
- Added explicit `ChannelAlreadyClosed` handling in `ensure_dlx` and `recreate_dlx` to fail once with context instead of looping
- Added session liveness guard in `ensure_dlx` to skip DLX declaration when the session is not open (e.g. during recovery windows)

## Root Cause
The production log showed:
```
ERROR -- : Caught an exception while recovering exchange legion.apollo.dlx: #<Bunny::ChannelAlreadyClosed: cannot use a closed channel! Channel id: 40>
ERROR -- : Caught an exception while recovering queue legion.apollo.dlx.queue: #<Bunny::ChannelAlreadyClosed: cannot use a closed channel! Channel id: 39>
```

These errors come from Bunny's internal `recover_topology` (bunny-3.1.0/lib/bunny/session.rb:1095). When `ensure_dlx` declares the DLX exchange+queue via `dlx_ch.exchange_declare(...)`, Bunny's `TopologyRegistry` records those entities with a reference to `dlx_ch`. But `ensure_dlx` closes `dlx_ch` immediately in its `ensure` block. During recovery, Bunny calls `x.channel.exchange_declare(...)` on the now-dead channel, which throws `ChannelAlreadyClosed` — caught, logged, and the next entity is tried, but the topology is never successfully recovered.

## Files Changed
- `lib/legion/transport/queue.rb` — core fix in `declare_dlx`, `ensure_dlx`, `recreate_dlx`
- `lib/legion/transport/version.rb` — bump to 1.4.30
- `CHANGELOG.md` — entry for 1.4.30
- `spec/queue_dlx_recovery_spec.rb` — new spec reproducing the closed-channel scenario
- `spec/legion/transport/queue_passive_spec.rb` — updated expectations to match new method names

## Test plan
- [x] New spec verifying `declare_dlx` uses `_without_recording_topology` variants
- [x] New spec verifying `ensure_dlx` handles `ChannelAlreadyClosed` without raising
- [x] New spec verifying `ensure_dlx` returns early when session is closed
- [x] Full suite: 687 examples, 0 failures
- [x] RuboCop: 0 offenses